### PR TITLE
test(e2e): golden paths against current app (Lot 0 / 0.2)

### DIFF
--- a/e2e/golden-paths.spec.ts
+++ b/e2e/golden-paths.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, type Locator, type Page } from "@playwright/test"
+
+const CHART_SETTLE_MS = 400
+
+async function waitForChartStable(canvas: Locator, page: Page) {
+  let prev = await canvas.screenshot()
+  for (let i = 0; i < 10; i++) {
+    await page.waitForTimeout(100)
+    const next = await canvas.screenshot()
+    if (Buffer.compare(prev, next) === 0) return next
+    prev = next
+  }
+  return prev
+}
+
+test.describe("golden paths — ISO functional contract for refactor v2", () => {
+  test("navigates between the four routes via header links", async ({
+    page,
+  }) => {
+    await page.goto("/")
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      /Mortality in France/i
+    )
+
+    await page.getByRole("link", { name: /^Overview$/ }).click()
+    await expect(page).toHaveURL(/\/overview$/)
+
+    await page.getByRole("link", { name: /^Comparison$/ }).click()
+    await expect(page).toHaveURL(/\/comparison$/)
+
+    await page.getByRole("link", { name: /^Distribution$/ }).click()
+    await expect(page).toHaveURL(/\/distribution$/)
+
+    await page.getByRole("link", { name: /Mortality in France/i }).click()
+    await expect(page).toHaveURL(/\/$/)
+  })
+
+  test("toggles locale FR ↔ EN and updates user-facing labels", async ({
+    page,
+  }) => {
+    await page.goto("/overview")
+
+    await expect(page.getByRole("link", { name: /^Overview$/ })).toBeVisible()
+    await expect(page.getByRole("link", { name: /^Comparison$/ })).toBeVisible()
+    await expect(
+      page.getByRole("link", { name: /^Distribution$/ })
+    ).toBeVisible()
+
+    await page.getByTitle("français", { exact: true }).click()
+    await expect(page).toHaveURL(/\/fr\/overview$/)
+
+    await expect(
+      page.getByRole("link", { name: /Vue d'Ensemble/i })
+    ).toBeVisible()
+    await expect(page.getByRole("link", { name: /Comparaison/i })).toBeVisible()
+    await expect(page.getByRole("link", { name: /Répartition/i })).toBeVisible()
+
+    await page.getByTitle("english", { exact: true }).click()
+    await expect(page).toHaveURL(/\/overview$/)
+    await expect(page.getByRole("link", { name: /^Overview$/ })).toBeVisible()
+  })
+
+  test("gender filter toggles active state and triggers chart re-render", async ({
+    page,
+  }) => {
+    await page.goto("/overview")
+
+    const canvas = page.locator("canvas").first()
+    await expect(canvas).toBeVisible()
+    const initial = await waitForChartStable(canvas, page)
+
+    const male = page.getByTitle("males", { exact: true })
+    const female = page.getByTitle("females", { exact: true })
+
+    await male.click()
+    await expect(male).toHaveClass(/active/)
+    await page.waitForTimeout(CHART_SETTLE_MS)
+    const afterMale = await waitForChartStable(canvas, page)
+    expect(Buffer.compare(initial, afterMale)).not.toBe(0)
+
+    await male.click()
+    await expect(male).not.toHaveClass(/active/)
+
+    await female.click()
+    await expect(female).toHaveClass(/active/)
+    await page.waitForTimeout(CHART_SETTLE_MS)
+    const afterFemale = await waitForChartStable(canvas, page)
+    expect(Buffer.compare(initial, afterFemale)).not.toBe(0)
+    expect(Buffer.compare(afterMale, afterFemale)).not.toBe(0)
+  })
+
+  test("age range slider triggers chart re-render", async ({ page }) => {
+    await page.goto("/overview")
+
+    const canvas = page.locator("canvas").first()
+    await expect(canvas).toBeVisible()
+    const initial = await waitForChartStable(canvas, page)
+
+    const handles = page.getByRole("slider")
+    await expect(handles).toHaveCount(2)
+
+    await handles.first().focus()
+    await page.keyboard.press("ArrowRight")
+    await page.keyboard.press("ArrowRight")
+
+    await page.waitForTimeout(CHART_SETTLE_MS)
+    const after = await waitForChartStable(canvas, page)
+    expect(Buffer.compare(initial, after)).not.toBe(0)
+  })
+
+  test("comparison year toggle adds and removes a series", async ({ page }) => {
+    await page.goto("/comparison")
+
+    const yearButtons = page.locator("ul.years > li > button")
+    await expect(yearButtons.first()).toBeVisible({ timeout: 10_000 })
+
+    const canvas = page.locator("canvas").first()
+    await expect(canvas).toBeVisible()
+    const before = await waitForChartStable(canvas, page)
+
+    const firstYear = yearButtons.first()
+    const wasActive = ((await firstYear.getAttribute("class")) || "").includes(
+      "active"
+    )
+
+    await firstYear.click()
+    await page.waitForTimeout(CHART_SETTLE_MS)
+
+    const newClass = (await firstYear.getAttribute("class")) || ""
+    expect(newClass.includes("active")).toBe(!wasActive)
+
+    const after = await waitForChartStable(canvas, page)
+    expect(Buffer.compare(before, after)).not.toBe(0)
+
+    await firstYear.click()
+    await page.waitForTimeout(CHART_SETTLE_MS)
+    const restored = (await firstYear.getAttribute("class")) || ""
+    expect(restored.includes("active")).toBe(wasActive)
+  })
+})


### PR DESCRIPTION
Closes #226

## Summary

Five Playwright behavioral journeys covering the user-facing contract that must remain green after the refactor (= ISO functional contract):

- Nav between the four routes (`/`, `/overview`, `/comparison`, `/distribution`)
- FR ↔ EN locale toggle and label updates
- Gender filter (toggle Male / Female, assert chart re-renders)
- Age range slider (assert chart re-renders)
- Comparison year add/remove (toggle button state + chart re-render)

For "figures recompute" assertions, each filter/year journey takes a canvas screenshot before and after the interaction and compares bytes. This works against the current chart.js canvas and will continue to work when Lot 3 swaps charts to inline SVG (the screenshot still differs).

## Test plan

- [x] `yarn e2e` — 6 / 6 passing locally (5 golden paths + existing smoke)
- [x] `yarn test` — 30 / 30 unit tests passing
- [x] `yarn type-check` — clean
- [x] `yarn lint e2e/` — clean
- [x] `yarn e2e:visual` — passes (no visual specs yet, expected)
- [ ] CI green on `alpha`

## Notes

- Selector strategy favors role + accessible name (`getByRole("link" / "slider")`, `getByTitle("males"|"females", { exact: true })`) so the spec survives the redesign with minimal selector tweaks.
- Two locator escapes that should be revisited during Lot 4 once the new design lands:
  - Year buttons in the comparison view: no `aria-pressed` on master, so the active-state assertion uses `class~=active`. The new component should expose `aria-pressed` (or equivalent) and these tests can switch to that.
  - Comparison year list scoped via `ul.years > li > button` for now — same reason. A `role="group"` + accessible name or a stable test id would let us drop the CSS selector.
- `waitForChartStable` polls canvas screenshots until two consecutive frames match, to avoid flakes from async chart.js paint after SWR data arrives.