### PR TITLE
chore(ci): add Claude Code PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,57 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [alpha]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude review
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Lis d'abord `CLAUDE.md` à la racine du repo : il décrit le contexte du refactor v2 en cours, les conventions (i18n via `react-intl`, commentaires uniquement pour le WHY non-évident, pas de mention Claude dans les commits, pas de `--no-verify`), les choix de stack figés (Next 15 / React 19 / Tailwind 4 / Vitest / Playwright / charts SVG), et le découpage en lots.
+
+            Fais une revue de la PR avec ce focus, dans cet ordre :
+
+            1. **Scope** — l'issue fermée par la PR (cherche `Closes #<num>` dans la description) définit le périmètre. Signale toute dérive : refactor opportuniste, fichiers hors-scope, abstractions prématurées, fonctionnalités non demandées.
+            2. **Conventions du repo** — vérifie l'application des règles de `CLAUDE.md` (i18n, commentaires, pas de Co-Authored-By Claude, stack figée).
+            3. **ISO-fonctionnel** — si la PR touche au comportement utilisateur, les golden paths Playwright doivent rester verts à l'identique vs master. Signale tout écart de comportement.
+            4. **Qualité de code** — bugs potentiels, sécurité, perf, lisibilité, dead code.
+            5. **Tests** — la PR a-t-elle les tests exigés par l'issue (unit Vitest / e2e Playwright / visual selon le lot) ?
+
+            La branche PR est déjà checkoutée. Pour publier la review :
+            - `gh pr comment` pour le résumé top-level (un seul commentaire de synthèse).
+            - `mcp__github_inline_comment__create_inline_comment` (avec `confirmed: true`) pour les remarques ligne-à-ligne.
+            - Ne renvoie jamais le texte de la review en message — uniquement via les commentaires GitHub.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Read,Grep,Glob"


### PR DESCRIPTION
## Summary

Ajoute un workflow GitHub Actions qui fait faire à Claude Code une revue automatique des PR ouvertes vers `alpha`.

## Stratégie

- **Trigger**: `pull_request: [opened, synchronize]` ciblant `alpha`, plus mention `@claude` dans un commentaire de PR (re-review manuelle).
- **Sticky comment**: `track_progress: true` → un seul commentaire de review édité en place à chaque run, pas d'empilement entre commits.
- **Concurrency**: `cancel-in-progress` → si plusieurs pushs s'enchaînent, seul le dernier run de review tourne.
- **Auth**: `CLAUDE_CODE_OAUTH_TOKEN` (compte Claude Max) plutôt que clé API.
- **Scope du prompt**: Claude lit `CLAUDE.md` puis check dans l'ordre — scope vs `Closes #<num>`, conventions du repo, ISO-fonctionnel, qualité, présence des tests.

## Pourquoi merger sur `master` plutôt que `alpha`

`anthropics/claude-code-action` valide par sécurité que le YAML du workflow sur la PR est identique à celui de la branche par défaut (anti-exfiltration de secrets via une PR malveillante qui modifierait le workflow). La branche par défaut du repo est `master`, donc le fichier doit y atterrir avant que l'action s'autorise à tourner sur les PR vers `alpha`.

Le workflow ne se déclenche que sur PR vers `alpha` — il ne tournera jamais sur `master` lui-même. C'est purement de l'outillage CI, pas du code applicatif, donc compatible avec le principe "master untouched" du refactor (qui vise les changements fonctionnels).

## Test plan

- [ ] Merge → workflow présent sur master.
- [ ] Sur la prochaine PR vers `alpha` (sub-issue du refactor), vérifier qu'un commentaire sticky de Claude apparaît.
- [ ] Pousser un commit fixup sur cette même PR pour vérifier que le commentaire est édité en place et que le run précédent est bien annulé par le `concurrency.cancel-in-progress`.
- [ ] Tester `@claude` dans un commentaire pour forcer une re-review manuelle.