### PR TITLE
fix(ci): scope Claude Review concurrency group by event_name

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,7 +8,7 @@ on:
     types: [created]
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Bug introduit par [#263](https://github.com/chewam/mortality/pull/263) : `track_progress: true` fait poster à Claude un commentaire de progression, qui fire un `issue_comment` event. Cet event re-trigger le workflow ; comme la `concurrency.group` matchait entre `pull_request` et `issue_comment` events sur la même PR, le run issue_comment cancelait le run pull_request qui était en train de faire la review. Le run cancellé skippait ensuite via le `if:`, et aucune review n'apparaissait.

Fix : scoper le groupe de concurrence par `event_name`, pour que pull_request et issue_comment vivent dans des lanes de concurrence séparées.

## Pourquoi sur master

Identique à [#263](https://github.com/chewam/mortality/pull/263) : `claude-code-action` valide que le YAML du workflow sur la PR matche celui de la branche par défaut. Donc le fix doit aussi atterrir sur master pour que la validation passe sur les futures PR vers `alpha`. Une PR jumelle [#267](https://github.com/chewam/mortality/pull/267) porte le même fix sur `alpha`.

## Test plan

- [ ] Merger cette PR sur master.
- [ ] Merger #267 sur alpha (même commit).
- [ ] Sur la prochaine PR sub-issue ouverte vers alpha, vérifier qu'un commentaire sticky de Claude apparaît et que la review se complète sans cancellation.