### PR TITLE
docs(ci): explain id-token + clarify checkout caveat

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,6 +24,9 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      # id-token: required for the action's OIDC -> GitHub App token exchange
+      # used to post comments. Independent of CLAUDE_CODE_OAUTH_TOKEN, which
+      # only authenticates to the Anthropic API.
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +51,9 @@ jobs:
             4. **Qualité de code** — bugs potentiels, sécurité, perf, lisibilité, dead code.
             5. **Tests** — la PR a-t-elle les tests exigés par l'issue (unit Vitest / e2e Playwright / visual selon le lot) ?
 
-            La branche PR est déjà checkoutée. Pour publier la review :
+            Pour explorer le diff, passe systématiquement par `gh pr diff` et `gh pr view` plutôt que de te fier au working directory : sur l'event `pull_request` la PR est checkoutée, mais sur l'event `issue_comment` (mention `@claude`) le working directory est l'état par défaut du repo, pas le head de la PR.
+
+            Pour publier la review :
             - `gh pr comment` pour le résumé top-level (un seul commentaire de synthèse).
             - `mcp__github_inline_comment__create_inline_comment` (avec `confirmed: true`) pour les remarques ligne-à-ligne.
             - Ne renvoie jamais le texte de la review en message — uniquement via les commentaires GitHub.


### PR DESCRIPTION
## Summary

Donne suite aux deux remarques que Claude a posées en se reviewant lui-même sur [#267](https://github.com/chewam/mortality/pull/267) :

1. **`id-token: write`** — la review hedgait sur la nécessité de cette permission. Vérification dans les logs : l'action fait bien un `OIDC -> GitHub App token exchange` (indépendant du `CLAUDE_CODE_OAUTH_TOKEN` qui n'authentifie que l'API Anthropic). On garde la permission, mais on ajoute un commentaire pour expliquer le WHY puisque ce n'est pas évident.

2. **Prompt trompeur sur le checkout** — la phrase "la branche PR est déjà checkoutée" n'est vraie que pour l'event `pull_request`. Sur l'event `issue_comment` (mention `@claude`), `actions/checkout@v4` checkout l'état par défaut du repo, pas le head de la PR. On instruit l'agent de passer systématiquement par `gh pr diff` / `gh pr view`.

## Pourquoi sur master

Comme [#268](https://github.com/chewam/mortality/pull/268) : `claude-code-action` valide que le YAML du workflow sur la PR matche celui de master. Le fix doit donc atterrir aussi bien sur master que sur alpha. PR jumelle [#267](https://github.com/chewam/mortality/pull/267) porte le même commit côté alpha.

## Test plan

- [ ] Merger master + alpha (#267) — l'ordre n'a pas d'importance.
- [ ] Sur la prochaine PR sub-issue ouverte vers alpha, vérifier que la review tourne bien (validation passe car master == alpha).