### PR TITLE
test(utils): freeze business-calc outputs on real data (Lot 0 / 0.3)

### DIFF
--- a/__tests__/utils/comparison.test.tsx
+++ b/__tests__/utils/comparison.test.tsx
@@ -1,4 +1,6 @@
 import { getMaximum } from "../../src/components/charts/Comparison"
+import { sumYears } from "../../src/utils/index"
+import deaths from "../../public/data/deaths.json"
 
 describe("Test getMaximum()", () => {
   const data = [
@@ -96,5 +98,19 @@ describe("Test getMaximum()", () => {
   test("getMaximum(data) => { month: 1, value: 68974, year: 2017 }", () => {
     const res = getMaximum(data)
     expect(res).toEqual({ month: 1, value: 68974, year: 2017 })
+  })
+})
+
+describe("Test getMaximum() on real deaths.json", () => {
+  const male = (deaths as DeathsRawData).male.global
+  const female = (deaths as DeathsRawData).female.global
+  const mf = male.map((year, i) => sumYears([year, female[i]]))
+
+  test("regression: peak m+f month 2000-2024 = December 2022 (71484)", () => {
+    expect(getMaximum(mf.slice(0, 25))).toEqual({
+      month: 12,
+      value: 71484,
+      year: 2022,
+    })
   })
 })

--- a/__tests__/utils/overview.test.tsx
+++ b/__tests__/utils/overview.test.tsx
@@ -3,11 +3,29 @@ import {
   average,
   getDatalabelsDisplay,
 } from "../../src/components/charts/Overview"
+import deaths from "../../public/data/deaths.json"
+
+const male = (deaths as DeathsRawData).male.global
+const female = (deaths as DeathsRawData).female.global
 
 describe("Test average()", () => {
   test("average([0, 10]) => 5", () => {
     const res = average([0, 10])
     expect(res).toBe(5)
+  })
+
+  test("regression: average of 2000 male monthly = 23431.667", () => {
+    expect(average(male[0])).toBeCloseTo(23431.6667, 4)
+  })
+
+  test("regression: average of 2010 m+f monthly = 46396.5", () => {
+    const mf = male[10].map((m, i) => m + female[10][i])
+    expect(average(mf)).toBeCloseTo(46396.5, 4)
+  })
+
+  test("regression: 2020 m+f monthly avg = 56510.417 (COVID year)", () => {
+    const mf = male[20].map((m, i) => m + female[20][i])
+    expect(average(mf)).toBeCloseTo(56510.4167, 4)
   })
 })
 

--- a/__tests__/utils/utils-index.test.tsx
+++ b/__tests__/utils/utils-index.test.tsx
@@ -1,0 +1,95 @@
+import {
+  sumArray,
+  sumObjects,
+  sumYears,
+  getYearPopulation,
+} from "../../src/utils/index"
+import deaths from "../../public/data/deaths.json"
+
+const male = (deaths as DeathsRawData).male.global
+const female = (deaths as DeathsRawData).female.global
+
+describe("sumArray()", () => {
+  test("returns 0 for empty array", () => {
+    expect(sumArray([])).toBe(0)
+  })
+
+  test("returns 0 when called with no argument (default [])", () => {
+    expect(sumArray()).toBe(0)
+  })
+
+  test("sums a small array", () => {
+    expect(sumArray([1, 2, 3, 4])).toBe(10)
+  })
+
+  test("regression: sum of male monthly deaths in 2000 = 281180", () => {
+    expect(sumArray(male[0])).toBe(281180)
+  })
+
+  test("regression: sum of female monthly deaths in 2000 = 265718", () => {
+    expect(sumArray(female[0])).toBe(265718)
+  })
+
+  test("regression: total deaths in 2022 (m+f) = 684591", () => {
+    expect(sumArray(male[22]) + sumArray(female[22])).toBe(684591)
+  })
+})
+
+describe("sumObjects()", () => {
+  test("merges keys and sums overlapping values", () => {
+    expect(sumObjects({ a: 1, b: 2 }, { b: 3, c: 4 })).toEqual({
+      a: 1,
+      b: 5,
+      c: 4,
+    })
+  })
+
+  test("returns {} for missing args (defaults)", () => {
+    expect(sumObjects()).toEqual({})
+  })
+
+  test("returns first arg unchanged when second is missing", () => {
+    expect(sumObjects({ a: 1, b: 2 })).toEqual({ a: 1, b: 2 })
+  })
+})
+
+describe("sumYears()", () => {
+  test("returns [] when given no years", () => {
+    expect(sumYears([])).toEqual([])
+  })
+
+  test("regression: male+female monthly deaths in 2000", () => {
+    expect(sumYears([male[0], female[0]])).toEqual([
+      60482, 49150, 46514, 43939, 42998, 41817, 42897, 42478, 40751, 44715,
+      44216, 46941,
+    ])
+  })
+
+  test("element-wise sum of three arrays of equal length", () => {
+    expect(
+      sumYears([
+        [1, 2, 3],
+        [10, 20, 30],
+        [100, 200, 300],
+      ])
+    ).toEqual([111, 222, 333])
+  })
+})
+
+describe("getYearPopulation()", () => {
+  test("returns French population for 2000", () => {
+    expect(getYearPopulation(2000)).toBe(60508150)
+  })
+
+  test("returns French population for 2010", () => {
+    expect(getYearPopulation(2010)).toBe(64612939)
+  })
+
+  test("returns French population for 2020", () => {
+    expect(getYearPopulation(2020)).toBe(67063703)
+  })
+
+  test("returns undefined for years outside the dataset", () => {
+    expect(getYearPopulation(1900)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #227

## Summary

Adds the third Lot 0 safety net: assertion-based unit tests that lock the numeric output of every business-calc function (`sumArray`, `sumObjects`, `sumYears`, `getYearPopulation`, `average`, `getMaximum`) on real `public/data/deaths.json` and `src/data/population.json`.

20 new tests, exact-number assertions (no `.toMatchSnapshot()` so the breakage is legible in PR diffs and survives the Jest → Vitest migration in Lot 1).

## What changed

- New `__tests__/utils/utils-index.test.tsx` — 16 tests across `sumArray`, `sumObjects`, `sumYears`, `getYearPopulation` (degenerate cases + real 2000 / 2010 / 2020 / 2022 regressions).
- Extended `__tests__/utils/overview.test.tsx` — 3 new `average()` regressions on real annual data (2000 male, 2010 m+f, 2020 COVID m+f).
- Extended `__tests__/utils/comparison.test.tsx` — 1 new `getMaximum()` regression on the m+f matrix sliced to **2000-2024** (frozen historic; current peak = December 2022, 71484).

No source code touched. No new fixtures (the existing JSON is the input).

## Test plan

- [x] `yarn test` — 50 passed (was 30) locally
- [x] `yarn type-check` — clean
- [x] `yarn lint __tests__/` — clean
- [x] `yarn e2e` — 6 passed (no regressions from new test file)
- [x] `yarn e2e:visual` — pass-with-no-tests (no specs yet, expected — Lot 4)
- [ ] CI green on alpha

## Notes

- `getMaximum` real-data test uses `mf.slice(0, 25)` (years 2000-2024) so it stays stable across `yarn update-data` runs that may revise the current/recent year. The other regressions lock years 2000, 2010, 2020, 2022 — all historic and frozen.
- Ticket body was rewritten during `/start-task` to make the deliverable, datasets, and acceptance criteria explicit (was: "extend tests"; now: list of functions + binary "≥ 8 new tests, exact numbers"). 20 new tests > 8.