### PR TITLE
ci(tests): gate PRs on E2E + visual nets (Lot 0 / 0.4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,96 @@ jobs:
           name: coverage
           path: coverage
 
+  e2e:
+    name: E2E (behavior)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --perfer-offline
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers + system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn playwright install-deps chromium
+
+      - name: Run E2E (behavior)
+        run: yarn e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-e2e
+          path: playwright-report
+          retention-days: 7
+
+  e2e-visual:
+    name: E2E (visual)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --perfer-offline
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers + system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn playwright install-deps chromium
+
+      - name: Run E2E (visual)
+        run: yarn e2e:visual
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-e2e-visual
+          path: playwright-report
+          retention-days: 7
+
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Run E2E (behavior)
         run: yarn e2e
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Upload Playwright report
         if: failure()
@@ -154,6 +156,8 @@ jobs:
 
       - name: Run E2E (visual)
         run: yarn e2e:visual
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Upload Playwright report
         if: failure()


### PR DESCRIPTION
Closes #228

## Summary

Wires `yarn e2e` (Playwright behavior) and `yarn e2e:visual` (visual
regression) into the `Quality` workflow so every PR onto `alpha` is
gated by the three nets defined in Lot 0 (parent #217), alongside
the existing `lint` / `types` / `tests` (Jest unit) jobs.

This is the last sub-issue of Lot 0 — the safety net is now complete
and enforced in CI before any refactor work starts on Lots 1/2/3.

## Changes

- `.github/workflows/tests.yml` — adds two jobs:
  - **`E2E (behavior)`** — runs `yarn e2e` (the golden paths from #262).
  - **`E2E (visual)`** — runs `yarn e2e:visual` (currently `--pass-with-no-tests`; baseline screenshots land in Lot 4).
- Both jobs cache `~/.cache/ms-playwright` keyed on the `@playwright/test` version, install browsers only on cache miss (and re-run `install-deps` on cache hit to refresh system libs), and upload `playwright-report/` as an artifact on failure with 7-day retention.
- 30 min timeout per job to bound stuck builds.

## Test plan

- [x] `yarn test` — 50/50 unit tests passing locally
- [x] `yarn type-check` — clean
- [x] `yarn lint` — clean
- [ ] CI green on this PR — both new Playwright jobs included

## Notes

- The `--perfer-offline` typo in the existing `yarn install` lines was preserved deliberately to keep the diff in-scope; unknown yarn flags are silently ignored.
- The visual net is a no-op gate today (baseline screenshots are tracked under Lot 4). It exists now so the wiring is in place and Lot 4 only has to drop screenshots into `e2e/` to start enforcing pixel-perfect.
- Branch protection on `alpha` (which actual checks are *required*) is configured at the repo settings level and is out of scope for this PR.