### PR TITLE
ci(claude-review): align master with alpha

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,19 +43,23 @@ jobs:
 
             Lis d'abord `CLAUDE.md` à la racine du repo : il décrit le contexte du refactor v2 en cours, les conventions (i18n via `react-intl`, commentaires uniquement pour le WHY non-évident, pas de mention Claude dans les commits, pas de `--no-verify`), les choix de stack figés (Next 15 / React 19 / Tailwind 4 / Vitest / Playwright / charts SVG), et le découpage en lots.
 
-            Fais une revue de la PR avec ce focus, dans cet ordre :
+            Tu es relecteur critique. **Ne signale que ce qui doit être corrigé.** Pas de compliments, pas de récapitulatif de ce que la PR fait bien, pas de checklist "ce que j'ai vérifié". Si tout est propre, ta synthèse tient en une ligne ("RAS, prêt à merger") et tu t'arrêtes là.
 
-            1. **Scope** — l'issue fermée par la PR (cherche `Closes #<num>` dans la description) définit le périmètre. Signale toute dérive : refactor opportuniste, fichiers hors-scope, abstractions prématurées, fonctionnalités non demandées.
-            2. **Conventions du repo** — vérifie l'application des règles de `CLAUDE.md` (i18n, commentaires, pas de Co-Authored-By Claude, stack figée).
-            3. **ISO-fonctionnel** — si la PR touche au comportement utilisateur, les golden paths Playwright doivent rester verts à l'identique vs master. Signale tout écart de comportement.
-            4. **Qualité de code** — bugs potentiels, sécurité, perf, lisibilité, dead code.
-            5. **Tests** — la PR a-t-elle les tests exigés par l'issue (unit Vitest / e2e Playwright / visual selon le lot) ?
+            Cherche des problèmes dans cet ordre — ignore tout ce qui est correct :
+
+            1. **Hors-scope** — fichiers ou changements non couverts par l'issue référencée par `Closes #<num>` (refactor opportuniste, abstractions prématurées, features non demandées).
+            2. **Violations de conventions `CLAUDE.md`** — i18n manquante, commentaires qui narrent le WHAT, `Co-Authored-By Claude`, choix de stack non-validés, `--no-verify`.
+            3. **Régression ISO-fonctionnelle** — si la PR touche au comportement utilisateur, dérive vs master.
+            4. **Bugs / sécurité / perf / dead code**.
+            5. **Tests manquants ou inadéquats** par rapport à ce que l'issue exige (unit Vitest / e2e Playwright / visual selon le lot).
+
+            Une remarque mineure de style sans impact (préférence personnelle, équivalence sémantique, lisibilité subjective) ne vaut pas un commentaire — laisse passer. Le seuil est : "est-ce qu'un autre relecteur humain demanderait un changement ?". Si non, silence.
 
             Pour explorer le diff, passe systématiquement par `gh pr diff` et `gh pr view` plutôt que de te fier au working directory : sur l'event `pull_request` la PR est checkoutée, mais sur l'event `issue_comment` (mention `@claude`) le working directory est l'état par défaut du repo, pas le head de la PR.
 
             Pour publier la review :
-            - `gh pr comment` pour le résumé top-level (un seul commentaire de synthèse).
-            - `mcp__github_inline_comment__create_inline_comment` (avec `confirmed: true`) pour les remarques ligne-à-ligne.
+            - `gh pr comment` : un seul commentaire top-level. Format : verdict en une ligne (`RAS, prêt à merger` ou `Changements demandés`), puis liste à puces des problèmes uniquement. Pas de sections, pas de bullets cochés, pas de "ce qui est bien".
+            - `mcp__github_inline_comment__create_inline_comment` (avec `confirmed: true`) pour pointer un problème sur une ligne précise.
             - Ne renvoie jamais le texte de la review en message — uniquement via les commentaires GitHub.
 
           claude_args: |


### PR DESCRIPTION
## Summary

Sync `.github/workflows/claude-review.yml` on master with the version that's on `alpha` (commits #267 + #272). Workflow file only — no app code, no semver impact.

## Why

The Anthropic Code Action used by Claude Review enforces:

> The workflow file must exist and have identical content to the version on the repository's default branch.

`claude-review.yml` currently differs between master and alpha, so every PR onto alpha fails the validation step (e.g. PR #273). Aligning master fixes this.

## Test plan

- [ ] Once merged, rerun the Claude Review job on PR #273 (or any open PR onto alpha) and confirm it no longer fails with "Workflow validation failed".

## Notes

This is a deliberate exception to the "do not touch master during refactor v2" rule from `CLAUDE.md` — the change is workflow-only, doesn't affect the 1.x app behavior, and is necessary to unblock the refactor v2 review pipeline.