### PR TITLE
feat(tokens): Graphite palette + modern type aliases via @theme (Lot 2 / 2.2)

### DIFF
--- a/__tests__/styles/theme-tokens.test.ts
+++ b/__tests__/styles/theme-tokens.test.ts
@@ -52,19 +52,19 @@ describe("@theme tokens (Graphite palette + modern typography)", () => {
 
   test("--font-display references Inter Tight then Inter", () => {
     expect(tokens["--font-display"]).toBe(
-      "var(--font-inter-tight), var(--font-inter), -apple-system, sans-serif",
+      "var(--font-inter-tight), var(--font-inter), -apple-system, sans-serif"
     )
   })
 
   test("--font-body references Inter", () => {
     expect(tokens["--font-body"]).toBe(
-      "var(--font-inter), -apple-system, sans-serif",
+      "var(--font-inter), -apple-system, sans-serif"
     )
   })
 
   test("--font-mono references JetBrains Mono", () => {
     expect(tokens["--font-mono"]).toBe(
-      "var(--font-jetbrains-mono), ui-monospace, monospace",
+      "var(--font-jetbrains-mono), ui-monospace, monospace"
     )
   })
 

--- a/__tests__/styles/theme-tokens.test.ts
+++ b/__tests__/styles/theme-tokens.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+const CSS_PATH = path.resolve(__dirname, "../../src/styles/tailwind.css")
+
+function parseThemeBlock(css: string): Record<string, string> {
+  const match = css.match(/@theme\s*\{([\s\S]*?)\n\}/)
+  if (!match) throw new Error("@theme block not found in tailwind.css")
+  const body = match[1]
+  const tokens: Record<string, string> = {}
+  for (const decl of body.split(";")) {
+    const trimmed = decl.trim()
+    if (!trimmed) continue
+    const sep = trimmed.indexOf(":")
+    if (sep === -1) continue
+    const name = trimmed.slice(0, sep).trim()
+    const value = trimmed
+      .slice(sep + 1)
+      .trim()
+      .replace(/\s+/g, " ")
+    tokens[name] = value
+  }
+  return tokens
+}
+
+describe("@theme tokens (Graphite palette + modern typography)", () => {
+  const css = readFileSync(CSS_PATH, "utf8")
+  const tokens = parseThemeBlock(css)
+
+  const graphite: Record<string, string> = {
+    "--color-bg": "#FAFAF9",
+    "--color-surface": "#FFFFFF",
+    "--color-border": "#E7E5E4",
+    "--color-text": "#0C0A09",
+    "--color-text-dim": "#57534E",
+    "--color-text-faint": "#A8A29E",
+    "--color-accent": "#0C0A09",
+    "--color-accent-soft": "#E7E5E4",
+    "--color-male": "#3B82F6",
+    "--color-female": "#EC4899",
+    "--color-grid": "#F1EFEE",
+    "--color-danger": "#DC2626",
+    "--color-warn": "#D97706",
+    "--color-mute": "#78716C",
+  }
+
+  for (const [name, expected] of Object.entries(graphite)) {
+    test(`${name} = ${expected}`, () => {
+      expect(tokens[name]?.toUpperCase()).toBe(expected.toUpperCase())
+    })
+  }
+
+  test("--font-display references Inter Tight then Inter", () => {
+    expect(tokens["--font-display"]).toBe(
+      "var(--font-inter-tight), var(--font-inter), -apple-system, sans-serif",
+    )
+  })
+
+  test("--font-body references Inter", () => {
+    expect(tokens["--font-body"]).toBe(
+      "var(--font-inter), -apple-system, sans-serif",
+    )
+  })
+
+  test("--font-mono references JetBrains Mono", () => {
+    expect(tokens["--font-mono"]).toBe(
+      "var(--font-jetbrains-mono), ui-monospace, monospace",
+    )
+  })
+
+  test("--tracking-display matches modern preset (-0.04em)", () => {
+    expect(tokens["--tracking-display"]).toBe("-0.04em")
+  })
+
+  test("Roboto residue is gone from @theme", () => {
+    expect(tokens["--font-roboto"]).toBeUndefined()
+  })
+})

--- a/e2e/fonts.spec.ts
+++ b/e2e/fonts.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./fixtures"
 
 test.describe("fonts — Lot 2 / 2.1 next/font", () => {
-  test("--display, --body, --mono CSS variables are exposed on :root", async ({
+  test("--font-display, --font-body, --font-mono CSS variables are exposed on :root", async ({
     page,
   }) => {
     await page.goto("/")
@@ -9,9 +9,9 @@ test.describe("fonts — Lot 2 / 2.1 next/font", () => {
     const vars = await page.evaluate(() => {
       const cs = getComputedStyle(document.documentElement)
       return {
-        display: cs.getPropertyValue("--display").trim(),
-        body: cs.getPropertyValue("--body").trim(),
-        mono: cs.getPropertyValue("--mono").trim(),
+        display: cs.getPropertyValue("--font-display").trim(),
+        body: cs.getPropertyValue("--font-body").trim(),
+        mono: cs.getPropertyValue("--font-mono").trim(),
         fontInter: cs.getPropertyValue("--font-inter").trim(),
         fontInterTight: cs.getPropertyValue("--font-inter-tight").trim(),
         fontFraunces: cs.getPropertyValue("--font-fraunces").trim(),

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -10,12 +10,6 @@ const Head = () => {
       <title>{fm({ id: "Mortality in France" })}</title>
       <meta name="robots" content="all" />
       <link rel="icon" href="/favicon.ico" />
-      <link
-        as="font"
-        rel="preload"
-        crossOrigin=""
-        href="/fonts/Roboto-Regular.ttf"
-      />
       <meta
         property="og:title"
         content="Les chiffres de la mortalité en France"

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,20 +1,31 @@
 @import "tailwindcss";
 
 @theme {
-  --font-roboto: Roboto, arial, sans-serif;
-}
+  --color-bg: #FAFAF9;
+  --color-surface: #FFFFFF;
+  --color-border: #E7E5E4;
+  --color-text: #0C0A09;
+  --color-text-dim: #57534E;
+  --color-text-faint: #A8A29E;
+  --color-accent: #0C0A09;
+  --color-accent-soft: #E7E5E4;
+  --color-male: #3B82F6;
+  --color-female: #EC4899;
+  --color-grid: #F1EFEE;
+  --color-danger: #DC2626;
+  --color-warn: #D97706;
+  --color-mute: #78716C;
 
-:root {
-  --display:
-    var(--font-inter-tight), var(--font-inter), -apple-system, sans-serif;
-  --body: var(--font-inter), -apple-system, sans-serif;
-  --mono: var(--font-jetbrains-mono), ui-monospace, monospace;
+  --font-display: var(--font-inter-tight), var(--font-inter), -apple-system, sans-serif;
+  --font-body: var(--font-inter), -apple-system, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
+  --tracking-display: -0.04em;
 }
 
 @layer base {
   body {
     @apply text-base
-      font-roboto
+      font-body
       font-normal
       antialiased
       bg-gray-50
@@ -36,29 +47,5 @@
 
   h3 {
     @apply text-xl font-bold;
-  }
-
-  @font-face {
-    font-weight: 400;
-    font-style: normal;
-    font-display: swap;
-    font-family: Roboto;
-    src: url("/fonts/Roboto-Regular.ttf");
-  }
-
-  @font-face {
-    font-weight: 300;
-    font-display: swap;
-    font-style: italic;
-    font-family: Roboto;
-    src: url("/fonts/Roboto-Italic.ttf");
-  }
-
-  @font-face {
-    font-weight: 700;
-    font-display: swap;
-    font-style: normal;
-    font-family: Roboto;
-    src: url("/fonts/Roboto-Bold.ttf");
   }
 }


### PR DESCRIPTION
Closes #234

## Summary

Move design tokens to the Tailwind v4 `@theme` block in `src/styles/tailwind.css` so the new design system has a real home and Tailwind generates `text-text-dim`, `font-display`, `font-body`, … utilities at build. Tokens follow the **Graphite** palette (14 colors) and the **modern** typography preset (`display`/`body`/`mono` + `tracking-display`) defined in `NEW_VERSION/i18n.js`. Other palettes/presets are tweaks-panel options and stay out of scope (`tweaks-panel.jsx — DO NOT PORT`).

Same commit removes the Roboto residue inherited from the SCSS stack (`--font-roboto`, the three `@font-face` blocks, the `<link rel="preload">` in `<Head>`, and the `body @apply font-roboto` → now `font-body`). The fonts e2e from 2.1 was asserting on the interim `--display`/`--body`/`--mono` names; it's been aligned on the canonical `--font-*` names now that the tokens have a proper home.

## Test plan

- [x] `yarn test` — 69/69 passing locally (incl. new `__tests__/styles/theme-tokens.test.ts`, 19 assertions)
- [x] `yarn type-check` — clean
- [x] `yarn lint` — clean
- [x] `yarn e2e fonts` — 2/2 passing on the renamed `--font-*` vars
- [x] `yarn build` — compiles
- [x] `grep -rE "(font-roboto|Roboto)" src/` — 0 matches
- [ ] CI green on alpha

## Notes

- **Spacing**: no custom tokens. The values used in `NEW_VERSION/views.jsx` (4/6/8/10/12/14/16/24/28/48px) all map to the default Tailwind spacing scale.
- **Out of scope**: `public/fonts/Roboto-{Regular,Italic,Bold}.ttf` are now fully orphaned. Better picked up in Lot 6 (Finitions/cleanup) so this PR stays focused on tokens.