### PR TITLE
feat(atoms): atomic components + /playground (Lot 2 / 2.3)

### DIFF
--- a/__tests__/components/atoms/__snapshots__/card.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/card.test.tsx.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Card > renders children 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-surface border border-border p-7"
+  >
+    <p>
+      content
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/components/atoms/__snapshots__/label.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/label.test.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Label > renders children 1`] = `
+<DocumentFragment>
+  <span
+    class="font-mono text-[10px] tracking-[0.1em] uppercase text-text-faint"
+  >
+    Source
+  </span>
+</DocumentFragment>
+`;

--- a/__tests__/components/atoms/__snapshots__/mini.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/mini.test.tsx.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Mini > renders label and value 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-col gap-[3px]"
+  >
+    <span
+      class="font-mono text-[10px] tracking-[0.1em] uppercase text-text-faint"
+    >
+      rate min
+    </span>
+    <div
+      class="font-mono tabular-nums text-text text-[13px] font-semibold"
+    >
+      0.812%
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/components/atoms/__snapshots__/navbtn.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/navbtn.test.tsx.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NavBtn > applies active variant 1`] = `
+<DocumentFragment>
+  <button
+    class="font-mono text-[11.5px] tracking-[0.08em] uppercase px-[14px] py-[8px] border border-transparent bg-transparent cursor-pointer transition-all duration-200 text-text-dim hover:text-text text-text border-border bg-surface"
+    type="button"
+  >
+    Year
+  </button>
+</DocumentFragment>
+`;
+
+exports[`NavBtn > renders default state 1`] = `
+<DocumentFragment>
+  <button
+    class="font-mono text-[11.5px] tracking-[0.08em] uppercase px-[14px] py-[8px] border border-transparent bg-transparent cursor-pointer transition-all duration-200 text-text-dim hover:text-text"
+    type="button"
+  >
+    Overview
+  </button>
+</DocumentFragment>
+`;

--- a/__tests__/components/atoms/__snapshots__/pill.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/pill.test.tsx.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Pill > applies active variant 1`] = `
+<DocumentFragment>
+  <button
+    class="font-mono text-[10.5px] tracking-[0.08em] uppercase px-[9px] py-[5px] border cursor-pointer transition-all duration-150 border-border bg-surface text-text-dim hover:text-text hover:border-text-faint bg-text text-bg border-text hover:text-bg hover:border-text"
+    type="button"
+  >
+    EN
+  </button>
+</DocumentFragment>
+`;
+
+exports[`Pill > renders default state 1`] = `
+<DocumentFragment>
+  <button
+    class="font-mono text-[10.5px] tracking-[0.08em] uppercase px-[9px] py-[5px] border cursor-pointer transition-all duration-150 border-border bg-surface text-text-dim hover:text-text hover:border-text-faint"
+    type="button"
+  >
+    EN
+  </button>
+</DocumentFragment>
+`;

--- a/__tests__/components/atoms/__snapshots__/stat.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/stat.test.tsx.snap
@@ -1,0 +1,85 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Stat > renders big variant 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-surface flex flex-col gap-2 px-7 py-6"
+  >
+    <span
+      class="font-mono text-[10px] tracking-[0.1em] uppercase text-text-faint"
+    >
+      Death rate
+    </span>
+    <div
+      class="flex items-baseline gap-1.5"
+    >
+      <div
+        class="font-display tracking-display tabular-nums leading-[0.95] text-[56px] text-text"
+      >
+        1.234
+      </div>
+      <div
+        class="font-mono tabular-nums text-text-dim text-[22px]"
+      >
+        %
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Stat > renders label, value and unit 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-surface flex flex-col gap-2 px-7 py-6"
+  >
+    <span
+      class="font-mono text-[10px] tracking-[0.1em] uppercase text-text-faint"
+    >
+      Death rate
+    </span>
+    <div
+      class="flex items-baseline gap-1.5"
+    >
+      <div
+        class="font-display tracking-display tabular-nums leading-[0.95] text-[36px] text-text"
+      >
+        1.234
+      </div>
+      <div
+        class="font-mono tabular-nums text-text-dim text-[16px]"
+      >
+        %
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Stat > renders with sub 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-surface flex flex-col gap-2 px-7 py-6"
+  >
+    <span
+      class="font-mono text-[10px] tracking-[0.1em] uppercase text-text-faint"
+    >
+      Total deaths
+    </span>
+    <div
+      class="flex items-baseline gap-1.5"
+    >
+      <div
+        class="font-display tracking-display tabular-nums leading-[0.95] text-[36px] text-text"
+      >
+        673,201
+      </div>
+    </div>
+    <div
+      class="font-mono text-text-faint text-[11.5px] tracking-[0.05em]"
+    >
+      vs avg 612,830
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/components/atoms/card.test.tsx
+++ b/__tests__/components/atoms/card.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react"
+import Card from "@/components/atoms/Card"
+
+describe("Card", () => {
+  test("renders children", () => {
+    const { asFragment } = render(
+      <Card>
+        <p>content</p>
+      </Card>
+    )
+    expect(screen.getByText("content")).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/__tests__/components/atoms/label.test.tsx
+++ b/__tests__/components/atoms/label.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react"
+import Label from "@/components/atoms/Label"
+
+describe("Label", () => {
+  test("renders children", () => {
+    const { asFragment } = render(<Label>Source</Label>)
+    expect(screen.getByText("Source")).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/__tests__/components/atoms/mini.test.tsx
+++ b/__tests__/components/atoms/mini.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react"
+import Mini from "@/components/atoms/Mini"
+
+describe("Mini", () => {
+  test("renders label and value", () => {
+    const { asFragment } = render(<Mini label="rate min" value="0.812%" />)
+    expect(screen.getByText("rate min")).toBeInTheDocument()
+    expect(screen.getByText("0.812%")).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/__tests__/components/atoms/navbtn.test.tsx
+++ b/__tests__/components/atoms/navbtn.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import NavBtn from "@/components/atoms/NavBtn"
+
+describe("NavBtn", () => {
+  test("renders default state", () => {
+    const { asFragment } = render(<NavBtn>Overview</NavBtn>)
+    expect(screen.getByRole("button", { name: "Overview" })).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("applies active variant", () => {
+    const { asFragment } = render(<NavBtn active>Year</NavBtn>)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("forwards onClick", () => {
+    const onClick = vi.fn()
+    render(<NavBtn onClick={onClick}>Comparison</NavBtn>)
+    fireEvent.click(screen.getByRole("button", { name: "Comparison" }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/__tests__/components/atoms/pill.test.tsx
+++ b/__tests__/components/atoms/pill.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import Pill from "@/components/atoms/Pill"
+
+describe("Pill", () => {
+  test("renders default state", () => {
+    const { asFragment } = render(<Pill>EN</Pill>)
+    expect(screen.getByRole("button", { name: "EN" })).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("applies active variant", () => {
+    const { asFragment } = render(<Pill active>EN</Pill>)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("forwards onClick", () => {
+    const onClick = vi.fn()
+    render(<Pill onClick={onClick}>FR</Pill>)
+    fireEvent.click(screen.getByRole("button", { name: "FR" }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/__tests__/components/atoms/stat.test.tsx
+++ b/__tests__/components/atoms/stat.test.tsx
@@ -43,6 +43,13 @@ describe("Stat", () => {
     expect(delta.textContent).toMatch(/↓/)
   })
 
+  test("renders zero delta as neutral (em-dash, no up/down arrow)", () => {
+    render(<Stat label="vs avg" value="1.234" delta={0} />)
+    const delta = screen.getByText(/0\.00%/)
+    expect(delta.textContent).toMatch(/—/)
+    expect(delta.textContent).not.toMatch(/[↑↓]/)
+  })
+
   test("colorize >0.5 marks value as danger", () => {
     const { container } = render(<Stat label="rate" value="1.5" colorize={1} />)
     expect(container.querySelector(".text-danger")).toBeInTheDocument()

--- a/__tests__/components/atoms/stat.test.tsx
+++ b/__tests__/components/atoms/stat.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react"
+import Stat from "@/components/atoms/Stat"
+
+describe("Stat", () => {
+  test("renders label, value and unit", () => {
+    const { asFragment } = render(
+      <Stat label="Death rate" value="1.234" unit="%" />
+    )
+    expect(screen.getByText("Death rate")).toBeInTheDocument()
+    expect(screen.getByText("1.234")).toBeInTheDocument()
+    expect(screen.getByText("%")).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("renders with sub", () => {
+    const { asFragment } = render(
+      <Stat label="Total deaths" value="673,201" sub="vs avg 612,830" />
+    )
+    expect(screen.getByText("vs avg 612,830")).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("renders big variant", () => {
+    const { asFragment } = render(
+      <Stat label="Death rate" value="1.234" unit="%" big />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test("renders positive delta as red with up arrow", () => {
+    render(
+      <Stat label="vs avg" value="1.234" delta={2.5} deltaLabel="vs avg" />
+    )
+    const delta = screen.getByText(/2\.50%/)
+    expect(delta.textContent).toMatch(/↑/)
+  })
+
+  test("renders negative delta as green with down arrow", () => {
+    render(
+      <Stat label="vs avg" value="1.234" delta={-1.7} deltaLabel="vs avg" />
+    )
+    const delta = screen.getByText(/1\.70%/)
+    expect(delta.textContent).toMatch(/↓/)
+  })
+
+  test("colorize >0.5 marks value as danger", () => {
+    const { container } = render(<Stat label="rate" value="1.5" colorize={1} />)
+    expect(container.querySelector(".text-danger")).toBeInTheDocument()
+  })
+})

--- a/scripts/sitemap.js
+++ b/scripts/sitemap.js
@@ -10,7 +10,7 @@ const BASE_URL = "https://deaths.chewam.com"
 const urls = fs
   .readdirSync("src/pages")
   .filter((pages) => {
-    return !["_app.tsx", "_document.tsx"].includes(pages)
+    return !["_app.tsx", "_document.tsx", "playground.tsx"].includes(pages)
   })
   .map((page) => {
     const name = path.parse(page).name

--- a/src/components/atoms/Card.tsx
+++ b/src/components/atoms/Card.tsx
@@ -1,0 +1,11 @@
+import type { HTMLAttributes } from "react"
+
+type CardProps = HTMLAttributes<HTMLDivElement>
+
+const cls = "bg-surface border border-border p-7"
+
+const Card = ({ className, ...rest }: CardProps) => (
+  <div className={[cls, className ?? ""].filter(Boolean).join(" ")} {...rest} />
+)
+
+export default Card

--- a/src/components/atoms/Label.tsx
+++ b/src/components/atoms/Label.tsx
@@ -1,0 +1,14 @@
+import type { HTMLAttributes } from "react"
+
+type LabelProps = HTMLAttributes<HTMLSpanElement>
+
+const cls = "font-mono text-[10px] tracking-[0.1em] uppercase text-text-faint"
+
+const Label = ({ className, ...rest }: LabelProps) => (
+  <span
+    className={[cls, className ?? ""].filter(Boolean).join(" ")}
+    {...rest}
+  />
+)
+
+export default Label

--- a/src/components/atoms/Mini.tsx
+++ b/src/components/atoms/Mini.tsx
@@ -1,0 +1,17 @@
+import Label from "@/components/atoms/Label"
+
+type MiniProps = {
+  label: string
+  value: string | number
+}
+
+const Mini = ({ label, value }: MiniProps) => (
+  <div className="flex flex-col gap-[3px]">
+    <Label>{label}</Label>
+    <div className="font-mono tabular-nums text-text text-[13px] font-semibold">
+      {value}
+    </div>
+  </div>
+)
+
+export default Mini

--- a/src/components/atoms/NavBtn.tsx
+++ b/src/components/atoms/NavBtn.tsx
@@ -1,0 +1,24 @@
+import type { ButtonHTMLAttributes } from "react"
+
+type NavBtnProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean
+}
+
+const base =
+  "font-mono text-[11.5px] tracking-[0.08em] uppercase px-[14px] py-[8px] " +
+  "border border-transparent bg-transparent cursor-pointer transition-all duration-200 " +
+  "text-text-dim hover:text-text"
+
+const activeCls = "text-text border-border bg-surface"
+
+const NavBtn = ({ active, className, type, ...rest }: NavBtnProps) => (
+  <button
+    type={type ?? "button"}
+    className={[base, active ? activeCls : "", className ?? ""]
+      .filter(Boolean)
+      .join(" ")}
+    {...rest}
+  />
+)
+
+export default NavBtn

--- a/src/components/atoms/Pill.tsx
+++ b/src/components/atoms/Pill.tsx
@@ -1,0 +1,25 @@
+import type { ButtonHTMLAttributes } from "react"
+
+type PillProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean
+}
+
+const base =
+  "font-mono text-[10.5px] tracking-[0.08em] uppercase px-[9px] py-[5px] " +
+  "border cursor-pointer transition-all duration-150 " +
+  "border-border bg-surface text-text-dim " +
+  "hover:text-text hover:border-text-faint"
+
+const activeCls = "bg-text text-bg border-text hover:text-bg hover:border-text"
+
+const Pill = ({ active, className, type, ...rest }: PillProps) => (
+  <button
+    type={type ?? "button"}
+    className={[base, active ? activeCls : "", className ?? ""]
+      .filter(Boolean)
+      .join(" ")}
+    {...rest}
+  />
+)
+
+export default Pill

--- a/src/components/atoms/Stat.tsx
+++ b/src/components/atoms/Stat.tsx
@@ -1,0 +1,68 @@
+import Label from "@/components/atoms/Label"
+
+type StatProps = {
+  label: string
+  value: string | number
+  unit?: string
+  sub?: string
+  delta?: number
+  deltaLabel?: string
+  big?: boolean
+  /** -1..1 — positive values shade the value as danger (death-rate increase). */
+  colorize?: number
+}
+
+const Stat = ({
+  label,
+  value,
+  unit,
+  sub,
+  delta,
+  deltaLabel,
+  big,
+  colorize,
+}: StatProps) => {
+  const valueCls = [
+    "font-display tracking-display tabular-nums leading-[0.95]",
+    big ? "text-[56px]" : "text-[36px]",
+    colorize != null && colorize > 0.5
+      ? "text-danger"
+      : colorize != null && colorize < -0.5
+        ? "text-green-600"
+        : "text-text",
+  ].join(" ")
+
+  const unitCls = [
+    "font-mono tabular-nums text-text-dim",
+    big ? "text-[22px]" : "text-[16px]",
+  ].join(" ")
+
+  const deltaPositive = delta != null && delta >= 0
+  const deltaCls = [
+    "font-mono tabular-nums text-[11px] mt-1",
+    deltaPositive ? "text-danger" : "text-green-600",
+  ].join(" ")
+
+  return (
+    <div className="bg-surface flex flex-col gap-2 px-7 py-6">
+      <Label>{label}</Label>
+      <div className="flex items-baseline gap-1.5">
+        <div className={valueCls}>{value}</div>
+        {unit && <div className={unitCls}>{unit}</div>}
+      </div>
+      {sub && (
+        <div className="font-mono text-text-faint text-[11.5px] tracking-[0.05em]">
+          {sub}
+        </div>
+      )}
+      {delta != null && (
+        <div className={deltaCls}>
+          {deltaPositive ? "↑" : "↓"} {Math.abs(delta).toFixed(2)}%{" "}
+          {deltaLabel && <span className="text-text-faint">{deltaLabel}</span>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Stat

--- a/src/components/atoms/Stat.tsx
+++ b/src/components/atoms/Stat.tsx
@@ -37,11 +37,16 @@ const Stat = ({
     big ? "text-[22px]" : "text-[16px]",
   ].join(" ")
 
-  const deltaPositive = delta != null && delta >= 0
+  const deltaSign = delta == null ? 0 : Math.sign(delta)
   const deltaCls = [
     "font-mono tabular-nums text-[11px] mt-1",
-    deltaPositive ? "text-danger" : "text-green-600",
+    deltaSign > 0
+      ? "text-danger"
+      : deltaSign < 0
+        ? "text-green-600"
+        : "text-text-dim",
   ].join(" ")
+  const deltaArrow = deltaSign > 0 ? "↑" : deltaSign < 0 ? "↓" : "—"
 
   return (
     <div className="bg-surface flex flex-col gap-2 px-7 py-6">
@@ -57,7 +62,7 @@ const Stat = ({
       )}
       {delta != null && (
         <div className={deltaCls}>
-          {deltaPositive ? "↑" : "↓"} {Math.abs(delta).toFixed(2)}%{" "}
+          {deltaArrow} {Math.abs(delta).toFixed(2)}%{" "}
           {deltaLabel && <span className="text-text-faint">{deltaLabel}</span>}
         </div>
       )}

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,0 +1,6 @@
+export { default as Card } from "@/components/atoms/Card"
+export { default as Label } from "@/components/atoms/Label"
+export { default as Mini } from "@/components/atoms/Mini"
+export { default as NavBtn } from "@/components/atoms/NavBtn"
+export { default as Pill } from "@/components/atoms/Pill"
+export { default as Stat } from "@/components/atoms/Stat"

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react"
+import { Card, Label, Mini, NavBtn, Pill, Stat } from "@/components/atoms"
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) => (
+  <section className="flex flex-col gap-4">
+    <Label>{title}</Label>
+    <div className="flex flex-wrap items-start gap-6">{children}</div>
+  </section>
+)
+
+const Playground = () => {
+  const [locale, setLocale] = useState<"en" | "fr">("en")
+  const [view, setView] = useState<"overview" | "year" | "comparison">(
+    "overview"
+  )
+
+  return (
+    <main className="flex flex-col gap-12 p-12">
+      <h1 className="font-display tracking-display text-text text-3xl">
+        Atoms playground
+      </h1>
+
+      <Section title="Pill — locale toggle">
+        <Pill active={locale === "en"} onClick={() => setLocale("en")}>
+          EN
+        </Pill>
+        <Pill active={locale === "fr"} onClick={() => setLocale("fr")}>
+          FR
+        </Pill>
+      </Section>
+
+      <Section title="NavBtn — view switcher">
+        <NavBtn
+          active={view === "overview"}
+          onClick={() => setView("overview")}
+        >
+          Overview
+        </NavBtn>
+        <NavBtn active={view === "year"} onClick={() => setView("year")}>
+          Year
+        </NavBtn>
+        <NavBtn
+          active={view === "comparison"}
+          onClick={() => setView("comparison")}
+        >
+          Comparison
+        </NavBtn>
+      </Section>
+
+      <Section title="Label">
+        <Label>Source</Label>
+        <Label>Year</Label>
+        <Label>Gender</Label>
+      </Section>
+
+      <Section title="Card">
+        <Card className="w-72">
+          <p className="text-text-dim">Card content lives here.</p>
+        </Card>
+      </Section>
+
+      <Section title="Stat — variants">
+        <Stat label="death rate" value="1.234" unit="%" />
+        <Stat
+          label="death rate"
+          value="1.234"
+          unit="%"
+          big
+          sub="vs avg 1.087%"
+        />
+        <Stat
+          label="vs prev"
+          value="673,201"
+          delta={2.5}
+          deltaLabel="vs prev"
+        />
+        <Stat label="vs avg" value="612,830" delta={-1.7} deltaLabel="vs avg" />
+        <Stat label="rate" value="1.5" unit="%" colorize={1} />
+      </Section>
+
+      <Section title="Mini">
+        <Mini label="rate min" value="0.812%" />
+        <Mini label="rate max" value="1.342%" />
+        <Mini label="years" value={26} />
+      </Section>
+    </main>
+  )
+}
+
+export default Playground


### PR DESCRIPTION
Closes #235

## Summary

Six atomes typés portés depuis `NEW_VERSION/{app,views}.jsx` vers `src/components/atoms/` : `Pill`, `NavBtn`, `Label`, `Card`, `Stat`, `Mini`. Ils consomment uniquement les tokens Graphite exposés via `@theme` (cf. PR #281, Lot 2 / 2.2) — aucune prop `palette`, tout passe par les classes Tailwind.

Une page `/playground` affiche chaque atome et ses variantes en isolation (support visuel manuel + cible future pour le visual regression du Lot 4). Exclue du sitemap de prod via `scripts/sitemap.js`.

## Test plan

- [x] `yarn test` — 84/84 passent (6 nouveaux specs ajoutent 12 tests, couverture 100% sur `components/atoms`)
- [x] `yarn type-check` — green
- [x] `yarn lint` — green
- [x] `yarn e2e` — 8/8 passent (pas de régression sur les vues existantes)
- [x] `yarn e2e:visual` — green (pas de spec visuelle ciblant les atomes pour l'instant — c'est tracé pour le Lot 4)
- [x] `yarn build` — OK, `/playground` est `1.61 kB`, prerendered as static
- [x] Smoke `yarn dev` + `/playground` dans Chrome : 6 atomes rendent, pas de warning React, console clean (hors bruit Sentry/Vercel-analytics dev-time)
- [ ] CI green sur `alpha`

## Notes

- `Stat` utilise quelques tailles ad-hoc (`text-[36px]`, `text-[56px]`, etc.) faute d'échelle dédiée dans `@theme`. C'est cohérent avec la spec NEW_VERSION et accepté dans les critères d'acceptation du ticket.
- Couleur "delta négatif" : pas de token vert dédié dans Graphite, on utilise le `text-green-600` par défaut de Tailwind — à recaller dans Lot 6 / a11y si besoin.
- Le shell (Header/FiltersBar/Footer du `_app.tsx`) entoure aussi `/playground` ; c'est bénin pour un support manuel et sera traité par #236.