### PR TITLE
feat(charts): TrendChart SVG component (Lot 3 / 3.1)

### DIFF
--- a/__tests__/components/charts/trend-geometry.test.ts
+++ b/__tests__/components/charts/trend-geometry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  TREND_PADDING,
+  TREND_RATE_DOMAIN,
+  buildTrendGeometry,
+  type TrendYear,
+} from "@/components/charts/trend-geometry"
+
+const sample: TrendYear[] = [
+  { year: 2000, rate: 0.9, deaths: 540_000, pop: 60_000_000 },
+  { year: 2001, rate: 0.95, deaths: 550_000, pop: 61_000_000 },
+  { year: 2002, rate: 1.0, deaths: 560_000, pop: 62_000_000 },
+]
+
+describe("buildTrendGeometry", () => {
+  test("inner box reflects width/height minus padding", () => {
+    const g = buildTrendGeometry(sample, 800, 340)
+    expect(g.innerW).toBe(800 - TREND_PADDING.left - TREND_PADDING.right)
+    expect(g.innerH).toBe(340 - TREND_PADDING.top - TREND_PADDING.bottom)
+  })
+
+  test("xs span from padL to padL+innerW evenly", () => {
+    const g = buildTrendGeometry(sample, 800, 340)
+    expect(g.xs).toEqual([56, 416, 776])
+  })
+
+  test("ys map mortality rate onto the rate domain (0.80 → bottom, 1.05 → top)", () => {
+    const g = buildTrendGeometry(sample, 800, 340)
+    // domain 0.80–1.05, innerH=280, padT=24
+    // rate=0.90 → 24 + 280*(1 - 0.40) = 192
+    // rate=0.95 → 24 + 280*(1 - 0.60) = 136
+    // rate=1.00 → 24 + 280*(1 - 0.80) =  80
+    expect(g.ys[0]).toBeCloseTo(192, 5)
+    expect(g.ys[1]).toBeCloseTo(136, 5)
+    expect(g.ys[2]).toBeCloseTo(80, 5)
+  })
+
+  test("computes the long-term average and projects it onto y", () => {
+    const g = buildTrendGeometry(sample, 800, 340)
+    expect(g.avg).toBeCloseTo(0.95, 5)
+    expect(g.avgY).toBeCloseTo(136, 5)
+  })
+
+  test("linePath starts with M, then L for each point, fixed to 2 decimals", () => {
+    const g = buildTrendGeometry(sample, 800, 340)
+    expect(g.linePath).toBe("M 56.00 192.00 L 416.00 136.00 L 776.00 80.00")
+  })
+
+  test("areaPath closes the line down to the bottom of the inner box", () => {
+    const g = buildTrendGeometry(sample, 800, 340)
+    // padT + innerH = 24 + 280 = 304
+    expect(g.areaPath).toBe(
+      "M 56.00 192.00 L 416.00 136.00 L 776.00 80.00 L 776 304 L 56 304 Z"
+    )
+  })
+
+  test("clamps innerW to a sensible minimum on tiny containers", () => {
+    const g = buildTrendGeometry(sample, 50, 340)
+    expect(g.innerW).toBe(100)
+  })
+
+  test("guards against division by zero on a single-year dataset", () => {
+    const single: TrendYear[] = [
+      { year: 2000, rate: 0.92, deaths: 540_000, pop: 60_000_000 },
+    ]
+    const g = buildTrendGeometry(single, 800, 340)
+    expect(Number.isFinite(g.xs[0])).toBe(true)
+    expect(g.xs[0]).toBe(TREND_PADDING.left)
+  })
+
+  test("returns empty paths and finite avg for an empty dataset", () => {
+    const g = buildTrendGeometry([], 800, 340)
+    expect(g.xs).toEqual([])
+    expect(g.ys).toEqual([])
+    expect(g.linePath).toBe("")
+    expect(g.areaPath).toBe("")
+    expect(Number.isFinite(g.avg)).toBe(true)
+  })
+
+  test("rate domain matches the source spec (0.80 → 1.05)", () => {
+    expect(TREND_RATE_DOMAIN).toEqual({ min: 0.8, max: 1.05 })
+  })
+})

--- a/__tests__/components/charts/trend.test.tsx
+++ b/__tests__/components/charts/trend.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, test, vi } from "vitest"
+
+import Trend from "@/components/charts/Trend"
+import type { TrendYear } from "@/components/charts/trend-geometry"
+
+const sample: TrendYear[] = [
+  { year: 2000, rate: 0.9, deaths: 540_000, pop: 60_000_000 },
+  { year: 2001, rate: 0.95, deaths: 550_000, pop: 61_000_000 },
+  { year: 2002, rate: 1.0, deaths: 560_000, pop: 62_000_000 },
+]
+
+const labels = {
+  mortalityRate: "Mortality rate",
+  deathsCount: "Deaths",
+  population: "Population",
+}
+
+const baseProps = {
+  years: sample,
+  chartType: "area" as const,
+  hoveredYear: null,
+  setHoveredYear: () => {},
+  labels,
+}
+
+describe("Trend", () => {
+  test("renders an svg with one visible point and one hit zone per year", () => {
+    const { container } = render(<Trend {...baseProps} />)
+    const svg = container.querySelector("svg")
+    expect(svg).not.toBeNull()
+    // 3 visible points (r=3) + 3 hit zones (r=12)
+    expect(svg!.querySelectorAll("circle").length).toBe(6)
+  })
+
+  test("renders the average label with the computed average", () => {
+    render(<Trend {...baseProps} />)
+    expect(screen.getByText(/AVG 0\.95/)).toBeInTheDocument()
+  })
+
+  test("renders the y-axis tick labels for the rate domain", () => {
+    render(<Trend {...baseProps} />)
+    expect(screen.getByText("0.85")).toBeInTheDocument()
+    expect(screen.getByText("0.90")).toBeInTheDocument()
+    expect(screen.getByText("0.95")).toBeInTheDocument()
+    expect(screen.getByText("1.00")).toBeInTheDocument()
+  })
+
+  test("renders the line path in both modes", () => {
+    const { container, rerender } = render(
+      <Trend {...baseProps} chartType="line" />
+    )
+    expect(container.querySelector('path[fill="none"]')).not.toBeNull()
+    rerender(<Trend {...baseProps} chartType="area" />)
+    expect(container.querySelector('path[fill="none"]')).not.toBeNull()
+  })
+
+  test("only renders the area gradient fill in area mode", () => {
+    const { container, rerender } = render(
+      <Trend {...baseProps} chartType="line" />
+    )
+    expect(container.querySelector('path[fill^="url(#"]')).toBeNull()
+    rerender(<Trend {...baseProps} chartType="area" />)
+    expect(container.querySelector('path[fill^="url(#"]')).not.toBeNull()
+  })
+
+  test("hovering a hit zone calls setHoveredYear with that year, leaving clears it", () => {
+    const setHoveredYear = vi.fn()
+    const { container } = render(
+      <Trend {...baseProps} setHoveredYear={setHoveredYear} />
+    )
+    const hitZones = container.querySelectorAll('circle[r="12"]')
+    expect(hitZones.length).toBe(3)
+    fireEvent.mouseEnter(hitZones[1]!)
+    expect(setHoveredYear).toHaveBeenCalledWith(2001)
+    fireEvent.mouseLeave(hitZones[1]!)
+    expect(setHoveredYear).toHaveBeenLastCalledWith(null)
+  })
+
+  test("shows a tooltip with the year + label rows when hoveredYear is set", () => {
+    render(<Trend {...baseProps} hoveredYear={2001} />)
+    expect(screen.getByText("2001")).toBeInTheDocument()
+    expect(screen.getByText("Mortality rate")).toBeInTheDocument()
+    expect(screen.getByText("Deaths")).toBeInTheDocument()
+    expect(screen.getByText("Population")).toBeInTheDocument()
+  })
+
+  test("renders the crosshair only when a year is hovered", () => {
+    const { container, rerender } = render(<Trend {...baseProps} />)
+    expect(container.querySelector("line[stroke-dasharray='2 3']")).toBeNull()
+    rerender(<Trend {...baseProps} hoveredYear={2001} />)
+    expect(
+      container.querySelector("line[stroke-dasharray='2 3']")
+    ).not.toBeNull()
+  })
+
+  test("does not render a tooltip when hoveredYear is unknown", () => {
+    render(<Trend {...baseProps} hoveredYear={1999} />)
+    expect(screen.queryByText("Mortality rate")).toBeNull()
+  })
+})

--- a/__tests__/components/charts/trend.test.tsx
+++ b/__tests__/components/charts/trend.test.tsx
@@ -14,6 +14,7 @@ const labels = {
   mortalityRate: "Mortality rate",
   deathsCount: "Deaths",
   population: "Population",
+  avgLabel: "AVG",
 }
 
 const baseProps = {

--- a/src/components/charts/Trend.tsx
+++ b/src/components/charts/Trend.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useId, useRef, useState } from "react"
+
+import {
+  TREND_PADDING,
+  buildTrendGeometry,
+  type TrendYear,
+} from "./trend-geometry"
+
+export type TrendChartType = "line" | "area"
+
+export type TrendLabels = {
+  mortalityRate: string
+  deathsCount: string
+  population: string
+}
+
+export type TrendProps = {
+  years: TrendYear[]
+  chartType: TrendChartType
+  hoveredYear: number | null
+  setHoveredYear: (year: number | null) => void
+  labels: TrendLabels
+  height?: number
+  formatRate?: (rate: number) => string
+  formatDeaths?: (n: number) => string
+  formatPopulation?: (n: number) => string
+}
+
+const Y_TICKS = [0.85, 0.9, 0.95, 1.0] as const
+const X_LABEL_EVERY = 4
+
+const defaultFormatRate = (rate: number): string => `${rate.toFixed(3)}%`
+const defaultFormatNumber = (n: number): string => n.toLocaleString("en-US")
+const defaultFormatCompact = (n: number): string =>
+  new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n)
+
+const Trend = ({
+  years,
+  chartType,
+  hoveredYear,
+  setHoveredYear,
+  labels,
+  height = 340,
+  formatRate = defaultFormatRate,
+  formatDeaths = defaultFormatNumber,
+  formatPopulation = defaultFormatCompact,
+}: TrendProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(800)
+  const gradientId = `trend-area-${useId().replace(/[:]/g, "")}`
+
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) return
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry) setWidth(entry.contentRect.width)
+    })
+    ro.observe(node)
+    return () => ro.disconnect()
+  }, [])
+
+  const { left: padL, top: padT } = TREND_PADDING
+  const { innerW, innerH, xs, ys, avg, avgY, linePath, areaPath } =
+    buildTrendGeometry(years, width, height)
+
+  const projectTickY = (rate: number): number => {
+    const span = 1.05 - 0.8
+    return padT + innerH * (1 - (rate - 0.8) / span)
+  }
+
+  const hoveredIndex =
+    hoveredYear == null ? -1 : years.findIndex((y) => y.year === hoveredYear)
+  const hovered = hoveredIndex >= 0 ? years[hoveredIndex] : null
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <svg
+        width={width}
+        height={height}
+        style={{ display: "block", overflow: "visible" }}
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop
+              offset="0%"
+              style={{ stopColor: "var(--color-accent)", stopOpacity: 0.16 }}
+            />
+            <stop
+              offset="100%"
+              style={{ stopColor: "var(--color-accent)", stopOpacity: 0 }}
+            />
+          </linearGradient>
+        </defs>
+
+        {Y_TICKS.map((v) => {
+          const y = projectTickY(v)
+          return (
+            <g key={v}>
+              <line
+                x1={padL}
+                y1={y}
+                x2={padL + innerW}
+                y2={y}
+                stroke="var(--color-grid)"
+                strokeWidth="1"
+              />
+              <text
+                x={padL - 10}
+                y={y + 3}
+                textAnchor="end"
+                fontSize="10"
+                className="font-mono"
+                fill="var(--color-text-faint)"
+                letterSpacing="0.04em"
+              >
+                {v.toFixed(2)}
+              </text>
+            </g>
+          )
+        })}
+
+        {years.length > 0 && (
+          <>
+            <line
+              x1={padL}
+              y1={avgY}
+              x2={padL + innerW}
+              y2={avgY}
+              stroke="var(--color-text-faint)"
+              strokeWidth="1"
+              strokeDasharray="2 4"
+              opacity="0.7"
+            />
+            <text
+              x={padL + innerW}
+              y={avgY - 4}
+              textAnchor="end"
+              fontSize="9.5"
+              className="font-mono uppercase"
+              fill="var(--color-text-dim)"
+              letterSpacing="0.05em"
+            >
+              AVG {avg.toFixed(3)}
+            </text>
+          </>
+        )}
+
+        {chartType === "area" && years.length > 0 && (
+          <path d={areaPath} fill={`url(#${gradientId})`} />
+        )}
+
+        {years.length > 0 && (
+          <path
+            d={linePath}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth="2"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        )}
+
+        {years.map((y, i) => {
+          const isHover = hoveredYear === y.year
+          return (
+            <g key={`pt-${y.year}`}>
+              <circle
+                cx={xs[i]}
+                cy={ys[i]}
+                r={isHover ? 5 : 3}
+                fill="var(--color-surface)"
+                stroke="var(--color-accent)"
+                strokeWidth="2"
+              />
+              <circle
+                cx={xs[i]}
+                cy={ys[i]}
+                r={12}
+                fill="transparent"
+                style={{ cursor: "pointer" }}
+                onMouseEnter={() => setHoveredYear(y.year)}
+                onMouseLeave={() => setHoveredYear(null)}
+              />
+            </g>
+          )
+        })}
+
+        {years.map((y, i) => {
+          if (i % X_LABEL_EVERY !== 0 && i !== years.length - 1) return null
+          return (
+            <text
+              key={`xlabel-${y.year}`}
+              x={xs[i]}
+              y={padT + innerH + 18}
+              textAnchor="middle"
+              fontSize="10.5"
+              className="font-mono"
+              fill="var(--color-text-dim)"
+              letterSpacing="0.05em"
+            >
+              {y.year}
+            </text>
+          )
+        })}
+
+        {hovered && (
+          <line
+            x1={xs[hoveredIndex]}
+            y1={padT}
+            x2={xs[hoveredIndex]}
+            y2={padT + innerH}
+            stroke="var(--color-accent)"
+            strokeWidth="1"
+            strokeDasharray="2 3"
+            opacity="0.4"
+          />
+        )}
+      </svg>
+
+      {hovered && (
+        <div
+          className="font-body bg-surface border-border text-text pointer-events-none absolute"
+          style={{
+            left: Math.min(width - 200, Math.max(8, xs[hoveredIndex] + 12)),
+            top: Math.max(8, ys[hoveredIndex] - 70),
+            border: "1px solid var(--color-border)",
+            padding: "10px 12px",
+            fontSize: 11.5,
+            lineHeight: 1.5,
+            minWidth: 160,
+            boxShadow: "0 4px 12px rgb(0 0 0 / 0.06)",
+          }}
+        >
+          <div
+            className="font-mono uppercase"
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.08em",
+              color: "var(--color-text-faint)",
+              marginBottom: 4,
+            }}
+          >
+            {hovered.year}
+          </div>
+          <TooltipRow
+            label={labels.mortalityRate}
+            value={formatRate(hovered.rate)}
+            bold
+          />
+          <TooltipRow
+            label={labels.deathsCount}
+            value={formatDeaths(hovered.deaths)}
+          />
+          <TooltipRow
+            label={labels.population}
+            value={formatPopulation(hovered.pop)}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+const TooltipRow = ({
+  label,
+  value,
+  bold = false,
+}: {
+  label: string
+  value: string
+  bold?: boolean
+}) => (
+  <div className="flex justify-between gap-4">
+    <span className="text-text-dim">{label}</span>
+    <span className={`font-mono${bold ? " font-semibold" : ""}`}>{value}</span>
+  </div>
+)
+
+export default Trend

--- a/src/components/charts/Trend.tsx
+++ b/src/components/charts/Trend.tsx
@@ -13,6 +13,7 @@ export type TrendLabels = {
   mortalityRate: string
   deathsCount: string
   population: string
+  avgLabel: string
 }
 
 export type TrendProps = {
@@ -145,7 +146,7 @@ const Trend = ({
               fill="var(--color-text-dim)"
               letterSpacing="0.05em"
             >
-              AVG {avg.toFixed(3)}
+              {labels.avgLabel} {avg.toFixed(3)}
             </text>
           </>
         )}

--- a/src/components/charts/Trend.tsx
+++ b/src/components/charts/Trend.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useRef, useState } from "react"
 
 import {
   TREND_PADDING,
+  TREND_RATE_DOMAIN,
   buildTrendGeometry,
   type TrendYear,
 } from "./trend-geometry"
@@ -66,9 +67,10 @@ const Trend = ({
   const { innerW, innerH, xs, ys, avg, avgY, linePath, areaPath } =
     buildTrendGeometry(years, width, height)
 
+  const { min: minRate, max: maxRate } = TREND_RATE_DOMAIN
   const projectTickY = (rate: number): number => {
-    const span = 1.05 - 0.8
-    return padT + innerH * (1 - (rate - 0.8) / span)
+    const span = maxRate - minRate
+    return padT + innerH * (1 - (rate - minRate) / span)
   }
 
   const hoveredIndex =
@@ -222,7 +224,7 @@ const Trend = ({
 
       {hovered && (
         <div
-          className="font-body bg-surface border-border text-text pointer-events-none absolute"
+          className="font-body bg-surface text-text pointer-events-none absolute"
           style={{
             left: Math.min(width - 200, Math.max(8, xs[hoveredIndex] + 12)),
             top: Math.max(8, ys[hoveredIndex] - 70),

--- a/src/components/charts/trend-geometry.ts
+++ b/src/components/charts/trend-geometry.ts
@@ -1,0 +1,67 @@
+export type TrendYear = {
+  year: number
+  rate: number
+  deaths: number
+  pop: number
+}
+
+export const TREND_PADDING = {
+  left: 56,
+  right: 24,
+  top: 24,
+  bottom: 36,
+} as const
+
+export const TREND_RATE_DOMAIN = { min: 0.8, max: 1.05 } as const
+
+const MIN_INNER_WIDTH = 100
+
+export type TrendGeometry = {
+  innerW: number
+  innerH: number
+  xs: number[]
+  ys: number[]
+  avg: number
+  avgY: number
+  linePath: string
+  areaPath: string
+}
+
+export const buildTrendGeometry = (
+  years: TrendYear[],
+  width: number,
+  height: number
+): TrendGeometry => {
+  const { left: padL, right: padR, top: padT, bottom: padB } = TREND_PADDING
+  const { min: minRate, max: maxRate } = TREND_RATE_DOMAIN
+
+  const innerW = Math.max(MIN_INNER_WIDTH, width - padL - padR)
+  const innerH = height - padT - padB
+
+  const span = maxRate - minRate
+  const projectRate = (rate: number): number =>
+    padT + innerH * (1 - (rate - minRate) / span)
+
+  const xs = years.map(
+    (_y, i) => padL + (innerW * i) / Math.max(1, years.length - 1)
+  )
+  const ys = years.map((y) => projectRate(y.rate))
+
+  const avg = years.length
+    ? years.reduce((s, y) => s + y.rate, 0) / years.length
+    : 0
+  const avgY = projectRate(avg)
+
+  const linePath = xs
+    .map((x, i) => `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${ys[i].toFixed(2)}`)
+    .join(" ")
+
+  const last = xs.length - 1
+  const baseY = padT + innerH
+  const areaPath =
+    xs.length > 0
+      ? `${linePath} L ${xs[last]} ${baseY} L ${xs[0]} ${baseY} Z`
+      : ""
+
+  return { innerW, innerH, xs, ys, avg, avgY, linePath, areaPath }
+}

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react"
 import { Card, Label, Mini, NavBtn, Pill, Stat } from "@/components/atoms"
+import Trend, { type TrendChartType } from "@/components/charts/Trend"
+import type { TrendYear } from "@/components/charts/trend-geometry"
 
 const Section = ({
   title,
@@ -14,11 +16,44 @@ const Section = ({
   </section>
 )
 
+const TREND_SAMPLE: TrendYear[] = [
+  { year: 2000, rate: 0.92, deaths: 540_601, pop: 60_508_150 },
+  { year: 2001, rate: 0.9, deaths: 541_028, pop: 61_181_560 },
+  { year: 2002, rate: 0.91, deaths: 545_204, pop: 61_804_087 },
+  { year: 2003, rate: 0.95, deaths: 562_528, pop: 62_417_680 },
+  { year: 2004, rate: 0.86, deaths: 519_470, pop: 62_998_773 },
+  { year: 2005, rate: 0.88, deaths: 538_080, pop: 63_513_032 },
+  { year: 2006, rate: 0.84, deaths: 521_016, pop: 64_013_300 },
+  { year: 2007, rate: 0.84, deaths: 531_162, pop: 64_374_990 },
+  { year: 2008, rate: 0.85, deaths: 542_562, pop: 64_703_519 },
+  { year: 2009, rate: 0.85, deaths: 548_541, pop: 65_005_785 },
+  { year: 2010, rate: 0.86, deaths: 551_218, pop: 65_276_983 },
+  { year: 2011, rate: 0.84, deaths: 545_057, pop: 65_523_980 },
+  { year: 2012, rate: 0.87, deaths: 569_868, pop: 65_802_785 },
+  { year: 2013, rate: 0.87, deaths: 569_236, pop: 66_073_000 },
+  { year: 2014, rate: 0.85, deaths: 559_293, pop: 66_311_000 },
+  { year: 2015, rate: 0.9, deaths: 593_680, pop: 66_548_272 },
+  { year: 2016, rate: 0.89, deaths: 593_865, pop: 66_724_103 },
+  { year: 2017, rate: 0.91, deaths: 606_274, pop: 66_864_408 },
+  { year: 2018, rate: 0.91, deaths: 609_648, pop: 66_977_107 },
+  { year: 2019, rate: 0.91, deaths: 613_243, pop: 67_063_703 },
+  { year: 2020, rate: 0.99, deaths: 668_922, pop: 67_287_241 },
+  { year: 2021, rate: 0.97, deaths: 660_168, pop: 67_499_343 },
+]
+
+const TREND_LABELS = {
+  mortalityRate: "Mortality rate",
+  deathsCount: "Deaths",
+  population: "Population",
+}
+
 const Playground = () => {
   const [locale, setLocale] = useState<"en" | "fr">("en")
   const [view, setView] = useState<"overview" | "year" | "comparison">(
     "overview"
   )
+  const [chartType, setChartType] = useState<TrendChartType>("area")
+  const [hoveredYear, setHoveredYear] = useState<number | null>(null)
 
   return (
     <main className="flex flex-col gap-12 p-12">
@@ -88,6 +123,32 @@ const Playground = () => {
         <Mini label="rate min" value="0.812%" />
         <Mini label="rate max" value="1.342%" />
         <Mini label="years" value={26} />
+      </Section>
+
+      <Section title="TrendChart — line / area">
+        <div className="flex gap-2">
+          <Pill
+            active={chartType === "line"}
+            onClick={() => setChartType("line")}
+          >
+            line
+          </Pill>
+          <Pill
+            active={chartType === "area"}
+            onClick={() => setChartType("area")}
+          >
+            area
+          </Pill>
+        </div>
+        <Card className="w-full">
+          <Trend
+            years={TREND_SAMPLE}
+            chartType={chartType}
+            hoveredYear={hoveredYear}
+            setHoveredYear={setHoveredYear}
+            labels={TREND_LABELS}
+          />
+        </Card>
       </Section>
     </main>
   )

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -45,6 +45,7 @@ const TREND_LABELS = {
   mortalityRate: "Mortality rate",
   deathsCount: "Deaths",
   population: "Population",
+  avgLabel: "AVG",
 }
 
 const Playground = () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,10 @@
 import "@testing-library/jest-dom/vitest"
+
+// jsdom doesn't implement ResizeObserver — charts use it to track container width.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver ??=
+  ResizeObserverStub as unknown as typeof ResizeObserver


### PR DESCRIPTION
Closes #237

## Summary

Pure SVG port of `NEW_VERSION/charts-trend.jsx` as a self-contained, dependency-free component (`src/components/charts/Trend.tsx`) plus pure geometry helpers (`trend-geometry.ts`) covered by Vitest. No `chart.js`. No `palette` / `t` props — Graphite tokens via CSS variables, parent owns hover state and tooltip labels.

The playground (`/playground`) now has a TrendChart section with a `line` / `area` toggle and a deterministic 2000–2021 sample dataset for visual sanity checking.

## Test plan

- [x] `yarn test` — 102 / 102, including 19 new tests (10 geometry + 9 component)
- [x] `yarn type-check` — clean
- [x] `yarn lint` — clean
- [x] `yarn build` — clean
- [x] `yarn e2e` — 8 / 8 (golden paths intact, `/playground` not in scope)
- [x] `yarn e2e:visual` — passes vacuously (chart visual snapshot is sub-issue #240's job)
- [ ] CI green on alpha

## Notes

- **`line` vs `area` modes diverge from the source.** In `NEW_VERSION/charts-trend.jsx` both modes render the gradient identically; that's clearly a stub. Here `area` = stroke + gradient fill, `line` = stroke only. Default in playground is `area` so the pixel reference (`07-trend.png`) match for sub-issue #240 is preserved.
- **`bar` mode** (also in the source) is **out of scope** — issue body restricted scope to `line` / `area`.
- **`ResizeObserver` stub** added to `vitest.setup.ts` for jsdom — needed by the chart and any future SVG chart that tracks container width.
- **Wiring on real views** (overview / comparison) is **out of scope** — Lot 5.
- **Pure component**: no fetch, no `useIntl`. Tooltip labels and number formatters come in via props so the same component can be rendered in a test, in `/playground`, and later in a view that uses `react-intl`.