### PR TITLE
feat(charts): MonthlyChart SVG component (Lot 3 / 3.2)

### DIFF
--- a/__tests__/components/charts/monthly-geometry.test.ts
+++ b/__tests__/components/charts/monthly-geometry.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  MONTHLY_DEFAULT_DOMAIN_MAX,
+  MONTHLY_PADDING,
+  MONTHLY_Y_TICKS,
+  buildMonthlyGeometry,
+  computeMonthlyDomainMax,
+  type MonthlyYear,
+} from "@/components/charts/monthly-geometry"
+
+const constYear = (year: number, value: number): MonthlyYear => ({
+  year,
+  monthly: Array.from({ length: 12 }, () => value),
+})
+
+const sample: MonthlyYear[] = [
+  constYear(2018, 50_000),
+  constYear(2019, 60_000),
+  // 2020 — varies month to month
+  {
+    year: 2020,
+    monthly: [
+      55_000, 50_000, 65_000, 75_000, 60_000, 50_000, 50_000, 50_000, 50_000,
+      55_000, 60_000, 70_000,
+    ],
+  },
+]
+
+describe("computeMonthlyDomainMax", () => {
+  test("returns the default 80k when all values are below it", () => {
+    const years: MonthlyYear[] = [
+      constYear(2018, 50_000),
+      constYear(2019, 60_000),
+    ]
+    expect(computeMonthlyDomainMax(years)).toBe(MONTHLY_DEFAULT_DOMAIN_MAX)
+    expect(MONTHLY_DEFAULT_DOMAIN_MAX).toBe(80_000)
+  })
+
+  test("rounds the max up to the nearest 10k when the data exceeds 80k", () => {
+    const years: MonthlyYear[] = [constYear(2020, 81_500)]
+    expect(computeMonthlyDomainMax(years)).toBe(90_000)
+  })
+
+  test("returns the default on an empty dataset", () => {
+    expect(computeMonthlyDomainMax([])).toBe(MONTHLY_DEFAULT_DOMAIN_MAX)
+  })
+
+  test("is unaffected by years with very low monthly values", () => {
+    const years: MonthlyYear[] = [
+      constYear(2018, 30_000),
+      constYear(2019, 25_000),
+    ]
+    expect(computeMonthlyDomainMax(years)).toBe(MONTHLY_DEFAULT_DOMAIN_MAX)
+  })
+})
+
+describe("buildMonthlyGeometry", () => {
+  test("inner box reflects width/height minus padding", () => {
+    const g = buildMonthlyGeometry(sample, 900, 420)
+    expect(g.innerW).toBe(900 - MONTHLY_PADDING.left - MONTHLY_PADDING.right)
+    expect(g.innerH).toBe(420 - MONTHLY_PADDING.top - MONTHLY_PADDING.bottom)
+  })
+
+  test("xs has 12 month positions evenly spaced from padL to padL+innerW", () => {
+    const g = buildMonthlyGeometry(sample, 900, 420)
+    expect(g.xs).toHaveLength(12)
+    expect(g.xs[0]).toBeCloseTo(MONTHLY_PADDING.left, 5)
+    expect(g.xs[11]).toBeCloseTo(MONTHLY_PADDING.left + g.innerW, 5)
+    // step is innerW / 11
+    const step = g.innerW / 11
+    expect(g.xs[6]! - g.xs[5]!).toBeCloseTo(step, 5)
+  })
+
+  test("clamps innerW to a sensible minimum on tiny containers", () => {
+    const g = buildMonthlyGeometry(sample, 50, 420)
+    expect(g.innerW).toBe(100)
+  })
+
+  test("series has one entry per year with values + ys + linePath", () => {
+    const g = buildMonthlyGeometry(sample, 900, 420)
+    expect(g.series.map((s) => s.year)).toEqual([2018, 2019, 2020])
+    for (const s of g.series) {
+      expect(s.values).toHaveLength(12)
+      expect(s.ys).toHaveLength(12)
+    }
+  })
+
+  test("ys project monthly values onto the [0, maxV] domain", () => {
+    const years: MonthlyYear[] = [constYear(2018, 40_000)]
+    const g = buildMonthlyGeometry(years, 900, 420)
+    // padT=32, innerH=420-32-50=338, maxV=80000, value=40000
+    // y = 32 + 338 * (1 - 40000/80000) = 32 + 169 = 201
+    for (const y of g.series[0]!.ys) expect(y).toBeCloseTo(201, 5)
+  })
+
+  test("linePath starts with M and uses L for subsequent points, fixed to 2 decimals", () => {
+    const years: MonthlyYear[] = [constYear(2018, 40_000)]
+    const g = buildMonthlyGeometry(years, 900, 420)
+    const expected = g.xs
+      .map((x, m) => `${m === 0 ? "M" : "L"} ${x.toFixed(2)} 201.00`)
+      .join(" ")
+    expect(g.series[0]!.linePath).toBe(expected)
+  })
+
+  test("returns an empty series and finite domain on an empty dataset", () => {
+    const g = buildMonthlyGeometry([], 900, 420)
+    expect(g.series).toEqual([])
+    expect(g.maxV).toBe(MONTHLY_DEFAULT_DOMAIN_MAX)
+    expect(g.xs).toHaveLength(12)
+  })
+
+  test("ticks are five evenly-spaced steps from 0 to 80k", () => {
+    expect(MONTHLY_Y_TICKS).toEqual([0, 20_000, 40_000, 60_000, 80_000])
+  })
+})

--- a/__tests__/components/charts/monthly-geometry.test.ts
+++ b/__tests__/components/charts/monthly-geometry.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, test } from "vitest"
 import {
   MONTHLY_DEFAULT_DOMAIN_MAX,
   MONTHLY_PADDING,
-  MONTHLY_Y_TICKS,
+  MONTHLY_TICK_COUNT,
   buildMonthlyGeometry,
   computeMonthlyDomainMax,
+  computeMonthlyYTicks,
   type MonthlyYear,
 } from "@/components/charts/monthly-geometry"
 
@@ -110,7 +111,31 @@ describe("buildMonthlyGeometry", () => {
     expect(g.xs).toHaveLength(12)
   })
 
-  test("ticks are five evenly-spaced steps from 0 to 80k", () => {
-    expect(MONTHLY_Y_TICKS).toEqual([0, 20_000, 40_000, 60_000, 80_000])
+  test("yTicks span [0, maxV] in evenly-spaced steps and adapt to the domain", () => {
+    const at80k = buildMonthlyGeometry(
+      [{ year: 2018, monthly: Array.from({ length: 12 }, () => 50_000) }],
+      900,
+      420
+    )
+    expect(at80k.yTicks).toEqual([0, 20_000, 40_000, 60_000, 80_000])
+
+    // COVID-style peak: max snaps to 100k, ticks rescale.
+    const atPeak = buildMonthlyGeometry(
+      [{ year: 2020, monthly: [...Array(11).fill(60_000), 95_000] }],
+      900,
+      420
+    )
+    expect(atPeak.yTicks).toEqual([0, 25_000, 50_000, 75_000, 100_000])
+  })
+})
+
+describe("computeMonthlyYTicks", () => {
+  test(`returns ${MONTHLY_TICK_COUNT} evenly-spaced ticks from 0 to maxV inclusive`, () => {
+    expect(computeMonthlyYTicks(80_000)).toEqual([
+      0, 20_000, 40_000, 60_000, 80_000,
+    ])
+    expect(computeMonthlyYTicks(120_000)).toEqual([
+      0, 30_000, 60_000, 90_000, 120_000,
+    ])
   })
 })

--- a/__tests__/components/charts/monthly.test.tsx
+++ b/__tests__/components/charts/monthly.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, test, vi } from "vitest"
+
+import Monthly, { type MonthlyLabels } from "@/components/charts/Monthly"
+import type {
+  MonthlyEvent,
+  MonthlyYear,
+} from "@/components/charts/monthly-geometry"
+
+const constMonthly = (v: number) => Array.from({ length: 12 }, () => v)
+
+const sample: MonthlyYear[] = [
+  { year: 2018, monthly: constMonthly(50_000) },
+  { year: 2019, monthly: constMonthly(55_000) },
+  { year: 2020, monthly: constMonthly(60_000) },
+]
+
+const labels: MonthlyLabels = {
+  months: [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ],
+  monthsLong: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+  deathsCount: "Deaths",
+}
+
+const events: MonthlyEvent[] = [{ year: 2020, month: 2, label: "COVID" }]
+
+const baseProps = {
+  years: sample,
+  selected: [] as number[],
+  events,
+  hovered: null,
+  setHovered: () => {},
+  labels,
+}
+
+describe("Monthly", () => {
+  test("renders an svg with 12 month labels", () => {
+    const { container } = render(<Monthly {...baseProps} mode="single" />)
+    expect(container.querySelector("svg")).not.toBeNull()
+    for (const m of labels.months) {
+      expect(screen.getByText(m)).toBeInTheDocument()
+    }
+  })
+
+  test("renders the y-axis tick labels (compact form, 0 to 80k)", () => {
+    render(<Monthly {...baseProps} mode="single" />)
+    expect(screen.getByText("0")).toBeInTheDocument()
+    expect(screen.getByText("20K")).toBeInTheDocument()
+    expect(screen.getByText("80K")).toBeInTheDocument()
+  })
+
+  test("single mode: highlights only the last year and ghosts the others", () => {
+    const { container } = render(<Monthly {...baseProps} mode="single" />)
+    // Ghost lines have opacity 0.18 (set via attribute)
+    const ghosts = container.querySelectorAll('path[opacity="0.18"]')
+    expect(ghosts.length).toBe(2) // 2018, 2019
+    // Highlighted path uses var(--color-accent)
+    const highlighted = container.querySelectorAll(
+      'path[stroke="var(--color-accent)"]'
+    )
+    expect(highlighted.length).toBe(1)
+  })
+
+  test("single mode: renders 12 visible points + 12 hit zones for the highlighted year", () => {
+    const { container } = render(<Monthly {...baseProps} mode="single" />)
+    // visible points are r=2.5 (or r=5 when hovered)
+    expect(container.querySelectorAll('circle[r="2.5"]').length).toBe(12)
+    expect(container.querySelectorAll('circle[r="14"]').length).toBe(12)
+  })
+
+  test("single mode: renders event annotations", () => {
+    render(<Monthly {...baseProps} mode="single" />)
+    expect(screen.getByText("COVID")).toBeInTheDocument()
+  })
+
+  test("compare mode: renders one line per selected year + a legend, no events", () => {
+    const { container } = render(
+      <Monthly {...baseProps} mode="compare" selected={[2018, 2020]} />
+    )
+    // No ghost lines in compare mode
+    expect(container.querySelectorAll('path[opacity="0.18"]').length).toBe(0)
+    // Legend entries: each selected year is rendered in svg <text>
+    expect(screen.getByText("2018")).toBeInTheDocument()
+    expect(screen.getByText("2020")).toBeInTheDocument()
+    // Events are not rendered in compare mode
+    expect(screen.queryByText("COVID")).toBeNull()
+  })
+
+  test("compare mode: hit zones are rendered for each selected year", () => {
+    const { container } = render(
+      <Monthly {...baseProps} mode="compare" selected={[2018, 2020]} />
+    )
+    // 12 hit zones per series × 2 series = 24
+    expect(container.querySelectorAll('circle[r="14"]').length).toBe(24)
+  })
+
+  test("hovering a hit zone calls setHovered with that {year, month}", () => {
+    const setHovered = vi.fn()
+    const { container } = render(
+      <Monthly {...baseProps} mode="single" setHovered={setHovered} />
+    )
+    const hits = container.querySelectorAll('circle[r="14"]')
+    expect(hits.length).toBe(12)
+    fireEvent.mouseEnter(hits[2]!)
+    expect(setHovered).toHaveBeenCalledWith({ year: 2020, month: 2 })
+    fireEvent.mouseLeave(hits[2]!)
+    expect(setHovered).toHaveBeenLastCalledWith(null)
+  })
+
+  test("renders the tooltip with month + year + value when hovered is set", () => {
+    render(
+      <Monthly
+        {...baseProps}
+        mode="single"
+        hovered={{ year: 2020, month: 2 }}
+      />
+    )
+    expect(screen.getByText(/March 2020/)).toBeInTheDocument()
+    expect(screen.getByText("Deaths")).toBeInTheDocument()
+    expect(screen.getByText("60,000")).toBeInTheDocument()
+  })
+
+  test("does not render a tooltip when hovered references an unknown year", () => {
+    render(
+      <Monthly
+        {...baseProps}
+        mode="single"
+        hovered={{ year: 1999, month: 0 }}
+      />
+    )
+    expect(screen.queryByText("Deaths")).toBeNull()
+  })
+})

--- a/src/components/charts/Monthly.tsx
+++ b/src/components/charts/Monthly.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useRef, useState } from "react"
+
+import {
+  MONTHLY_PADDING,
+  MONTHLY_Y_TICKS,
+  buildMonthlyGeometry,
+  projectMonthlyTickY,
+  type MonthlyEvent,
+  type MonthlyHover,
+  type MonthlyYear,
+} from "./monthly-geometry"
+
+export type MonthlyMode = "single" | "compare"
+
+export type MonthlyLabels = {
+  months: string[]
+  monthsLong: string[]
+  deathsCount: string
+}
+
+export type MonthlyProps = {
+  years: MonthlyYear[]
+  mode: MonthlyMode
+  selected: number[]
+  events: MonthlyEvent[]
+  hovered: MonthlyHover | null
+  setHovered: (h: MonthlyHover | null) => void
+  labels: MonthlyLabels
+  height?: number
+  formatNumber?: (n: number) => string
+  formatCompact?: (n: number) => string
+}
+
+const COMPARE_COLORS = [
+  "var(--color-accent)",
+  "var(--color-male)",
+  "var(--color-female)",
+  "var(--color-warn)",
+  "var(--color-danger)",
+  "var(--color-text-dim)",
+  "var(--color-text)",
+] as const
+
+const defaultFormatNumber = (n: number): string => n.toLocaleString("en-US")
+const defaultFormatCompact = (n: number): string =>
+  new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n)
+
+const Monthly = ({
+  years,
+  mode,
+  selected,
+  events,
+  hovered,
+  setHovered,
+  labels,
+  height = 420,
+  formatNumber = defaultFormatNumber,
+  formatCompact = defaultFormatCompact,
+}: MonthlyProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(900)
+
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) return
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry) setWidth(entry.contentRect.width)
+    })
+    ro.observe(node)
+    return () => ro.disconnect()
+  }, [])
+
+  const { left: padL, top: padT } = MONTHLY_PADDING
+  const { innerW, innerH, maxV, xs, series } = buildMonthlyGeometry(
+    years,
+    width,
+    height
+  )
+
+  const isSingle = mode === "single"
+
+  const highlighted = isSingle
+    ? series.slice(-1)
+    : (selected
+        .map((yr) => series.find((s) => s.year === yr))
+        .filter(Boolean) as typeof series)
+
+  const ghosts = isSingle ? series.slice(0, -1) : []
+
+  const visibleEvents = isSingle
+    ? events.filter((ev) => series.some((s) => s.year === ev.year))
+    : []
+
+  const colorFor = (idx: number) =>
+    COMPARE_COLORS[idx % COMPARE_COLORS.length] as string
+
+  const hoveredSeries =
+    hovered == null
+      ? null
+      : (series.find((s) => s.year === hovered.year) ?? null)
+  const hoveredX = hovered == null ? null : (xs[hovered.month] ?? null)
+  const hoveredY =
+    hoveredSeries == null || hovered == null
+      ? null
+      : (hoveredSeries.ys[hovered.month] ?? null)
+  const hoveredValue =
+    hoveredSeries == null || hovered == null
+      ? null
+      : (hoveredSeries.values[hovered.month] ?? null)
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <svg
+        width={width}
+        height={height}
+        style={{ display: "block", overflow: "visible" }}
+      >
+        {MONTHLY_Y_TICKS.map((v) => {
+          const y = projectMonthlyTickY(v, maxV, innerH)
+          return (
+            <g key={v}>
+              <line
+                x1={padL}
+                y1={y}
+                x2={padL + innerW}
+                y2={y}
+                stroke="var(--color-grid)"
+                strokeWidth="1"
+              />
+              <text
+                x={padL - 10}
+                y={y + 3}
+                textAnchor="end"
+                fontSize="10"
+                className="font-mono"
+                fill="var(--color-text-faint)"
+                letterSpacing="0.04em"
+              >
+                {formatCompact(v)}
+              </text>
+            </g>
+          )
+        })}
+
+        {labels.months.map((m, i) => (
+          <text
+            key={i}
+            x={xs[i]}
+            y={padT + innerH + 22}
+            textAnchor="middle"
+            fontSize="10.5"
+            className="font-mono uppercase"
+            fill="var(--color-text-dim)"
+            letterSpacing="0.05em"
+          >
+            {m}
+          </text>
+        ))}
+
+        {ghosts.map((s) => (
+          <path
+            key={`ghost-${s.year}`}
+            d={s.linePath}
+            fill="none"
+            stroke="var(--color-text-faint)"
+            strokeWidth="1"
+            opacity="0.18"
+          />
+        ))}
+
+        {highlighted.map((s, idx) => {
+          const color = isSingle ? "var(--color-accent)" : colorFor(idx)
+          const strokeWidth = isSingle ? 2.2 : 1.8
+          return (
+            <g key={`series-${s.year}`}>
+              <path
+                d={s.linePath}
+                fill="none"
+                stroke={color}
+                strokeWidth={strokeWidth}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+              {s.ys.map((y, m) => {
+                const isHover = hovered?.year === s.year && hovered.month === m
+                return (
+                  <g key={`pt-${s.year}-${m}`}>
+                    <circle
+                      cx={xs[m]}
+                      cy={y}
+                      r={isHover ? 5 : 2.5}
+                      fill="var(--color-surface)"
+                      stroke={color}
+                      strokeWidth="1.5"
+                    />
+                    <circle
+                      cx={xs[m]}
+                      cy={y}
+                      r={14}
+                      fill="transparent"
+                      style={{ cursor: "pointer" }}
+                      onMouseEnter={() =>
+                        setHovered({ year: s.year, month: m })
+                      }
+                      onMouseLeave={() => setHovered(null)}
+                    />
+                  </g>
+                )
+              })}
+            </g>
+          )
+        })}
+
+        {visibleEvents.map((ev, i) => {
+          const s = series.find((ss) => ss.year === ev.year)
+          if (!s) return null
+          const yPx = s.ys[ev.month]
+          const x = xs[ev.month]
+          if (yPx == null || x == null) return null
+          const labelY = padT + (i % 3) * 18 + 4
+          const labelText = ev.label
+          const labelW = labelText.length * 5.5 + 12
+          return (
+            <g key={`ev-${ev.year}-${ev.month}`}>
+              <line
+                x1={x}
+                y1={yPx}
+                x2={x}
+                y2={labelY + 12}
+                stroke="var(--color-warn)"
+                strokeWidth="1"
+                strokeDasharray="2 2"
+                opacity="0.5"
+              />
+              <circle
+                cx={x}
+                cy={yPx}
+                r="6"
+                fill="none"
+                stroke="var(--color-warn)"
+                strokeWidth="1.5"
+              />
+              <rect
+                x={x + 6}
+                y={labelY}
+                width={labelW}
+                height={14}
+                fill="var(--color-surface)"
+                stroke="var(--color-warn)"
+                strokeWidth="1"
+                rx="2"
+              />
+              <text
+                x={x + 12}
+                y={labelY + 10}
+                fontSize="9.5"
+                className="font-mono"
+                fill="var(--color-warn)"
+                letterSpacing="0.03em"
+              >
+                {labelText}
+              </text>
+            </g>
+          )
+        })}
+
+        {!isSingle && (
+          <g transform={`translate(${padL}, ${padT - 18})`}>
+            {highlighted.map((s, idx) => (
+              <g
+                key={`legend-${s.year}`}
+                transform={`translate(${idx * 70}, 0)`}
+              >
+                <line
+                  x1="0"
+                  y1="0"
+                  x2="14"
+                  y2="0"
+                  stroke={colorFor(idx)}
+                  strokeWidth="2"
+                />
+                <text
+                  x="20"
+                  y="3"
+                  fontSize="10.5"
+                  className="font-mono"
+                  fill="var(--color-text)"
+                >
+                  {s.year}
+                </text>
+              </g>
+            ))}
+          </g>
+        )}
+      </svg>
+
+      {hovered != null &&
+        hoveredSeries != null &&
+        hoveredX != null &&
+        hoveredY != null &&
+        hoveredValue != null && (
+          <div
+            className="font-body bg-surface text-text pointer-events-none absolute"
+            style={{
+              left: Math.min(width - 220, Math.max(8, hoveredX + 12)),
+              top: Math.max(8, hoveredY - 70),
+              border: "1px solid var(--color-border)",
+              padding: "10px 12px",
+              fontSize: 11.5,
+              lineHeight: 1.5,
+              minWidth: 180,
+              boxShadow: "0 4px 12px rgb(0 0 0 / 0.06)",
+            }}
+          >
+            <div
+              className="font-mono uppercase"
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.08em",
+                color: "var(--color-text-faint)",
+                marginBottom: 4,
+              }}
+            >
+              {labels.monthsLong[hovered.month]} {hovered.year}
+            </div>
+            <div className="flex justify-between gap-4">
+              <span className="text-text-dim">{labels.deathsCount}</span>
+              <span className="font-mono font-semibold">
+                {formatNumber(hoveredValue)}
+              </span>
+            </div>
+          </div>
+        )}
+    </div>
+  )
+}
+
+export default Monthly

--- a/src/components/charts/Monthly.tsx
+++ b/src/components/charts/Monthly.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react"
 
 import {
   MONTHLY_PADDING,
-  MONTHLY_Y_TICKS,
   buildMonthlyGeometry,
   projectMonthlyTickY,
   type MonthlyEvent,
@@ -74,7 +73,7 @@ const Monthly = ({
   }, [])
 
   const { left: padL, top: padT } = MONTHLY_PADDING
-  const { innerW, innerH, maxV, xs, series } = buildMonthlyGeometry(
+  const { innerW, innerH, maxV, xs, yTicks, series } = buildMonthlyGeometry(
     years,
     width,
     height
@@ -118,7 +117,7 @@ const Monthly = ({
         height={height}
         style={{ display: "block", overflow: "visible" }}
       >
-        {MONTHLY_Y_TICKS.map((v) => {
+        {yTicks.map((v) => {
           const y = projectMonthlyTickY(v, maxV, innerH)
           return (
             <g key={v}>

--- a/src/components/charts/monthly-geometry.ts
+++ b/src/components/charts/monthly-geometry.ts
@@ -1,0 +1,87 @@
+export type MonthlyYear = {
+  year: number
+  monthly: number[]
+}
+
+export type MonthlyEvent = {
+  year: number
+  month: number
+  label: string
+}
+
+export type MonthlyHover = {
+  year: number
+  month: number
+}
+
+export const MONTHLY_PADDING = {
+  left: 56,
+  right: 24,
+  top: 32,
+  bottom: 50,
+} as const
+
+export const MONTHLY_Y_TICKS = [0, 20_000, 40_000, 60_000, 80_000] as const
+export const MONTHLY_DEFAULT_DOMAIN_MAX = 80_000
+
+const MIN_INNER_WIDTH = 100
+const DOMAIN_STEP = 10_000
+
+export const computeMonthlyDomainMax = (years: MonthlyYear[]): number => {
+  const all = years.flatMap((y) => y.monthly)
+  if (all.length === 0) return MONTHLY_DEFAULT_DOMAIN_MAX
+  const max = Math.max(...all)
+  return Math.max(
+    MONTHLY_DEFAULT_DOMAIN_MAX,
+    Math.ceil(max / DOMAIN_STEP) * DOMAIN_STEP
+  )
+}
+
+export type MonthlySeries = {
+  year: number
+  values: number[]
+  ys: number[]
+  linePath: string
+}
+
+export type MonthlyGeometry = {
+  innerW: number
+  innerH: number
+  maxV: number
+  xs: number[]
+  series: MonthlySeries[]
+}
+
+export const buildMonthlyGeometry = (
+  years: MonthlyYear[],
+  width: number,
+  height: number
+): MonthlyGeometry => {
+  const { left: padL, right: padR, top: padT, bottom: padB } = MONTHLY_PADDING
+  const innerW = Math.max(MIN_INNER_WIDTH, width - padL - padR)
+  const innerH = height - padT - padB
+
+  const maxV = computeMonthlyDomainMax(years)
+  const projectY = (v: number): number => padT + innerH * (1 - v / maxV)
+
+  const xs = Array.from({ length: 12 }, (_, m) => padL + (innerW * m) / 11)
+
+  const series: MonthlySeries[] = years.map((y) => {
+    const values = y.monthly
+    const ys = values.map(projectY)
+    const linePath = xs
+      .map(
+        (x, m) => `${m === 0 ? "M" : "L"} ${x.toFixed(2)} ${ys[m]!.toFixed(2)}`
+      )
+      .join(" ")
+    return { year: y.year, values, ys, linePath }
+  })
+
+  return { innerW, innerH, maxV, xs, series }
+}
+
+export const projectMonthlyTickY = (
+  tick: number,
+  maxV: number,
+  innerH: number
+): number => MONTHLY_PADDING.top + innerH * (1 - tick / maxV)

--- a/src/components/charts/monthly-geometry.ts
+++ b/src/components/charts/monthly-geometry.ts
@@ -21,8 +21,8 @@ export const MONTHLY_PADDING = {
   bottom: 50,
 } as const
 
-export const MONTHLY_Y_TICKS = [0, 20_000, 40_000, 60_000, 80_000] as const
 export const MONTHLY_DEFAULT_DOMAIN_MAX = 80_000
+export const MONTHLY_TICK_COUNT = 5
 
 const MIN_INNER_WIDTH = 100
 const DOMAIN_STEP = 10_000
@@ -34,6 +34,14 @@ export const computeMonthlyDomainMax = (years: MonthlyYear[]): number => {
   return Math.max(
     MONTHLY_DEFAULT_DOMAIN_MAX,
     Math.ceil(max / DOMAIN_STEP) * DOMAIN_STEP
+  )
+}
+
+export const computeMonthlyYTicks = (maxV: number): number[] => {
+  const intervals = MONTHLY_TICK_COUNT - 1
+  return Array.from(
+    { length: MONTHLY_TICK_COUNT },
+    (_, i) => (maxV * i) / intervals
   )
 }
 
@@ -49,6 +57,7 @@ export type MonthlyGeometry = {
   innerH: number
   maxV: number
   xs: number[]
+  yTicks: number[]
   series: MonthlySeries[]
 }
 
@@ -65,6 +74,7 @@ export const buildMonthlyGeometry = (
   const projectY = (v: number): number => padT + innerH * (1 - v / maxV)
 
   const xs = Array.from({ length: 12 }, (_, m) => padL + (innerW * m) / 11)
+  const yTicks = computeMonthlyYTicks(maxV)
 
   const series: MonthlySeries[] = years.map((y) => {
     const values = y.monthly
@@ -77,7 +87,7 @@ export const buildMonthlyGeometry = (
     return { year: y.year, values, ys, linePath }
   })
 
-  return { innerW, innerH, maxV, xs, series }
+  return { innerW, innerH, maxV, xs, yTicks, series }
 }
 
 export const projectMonthlyTickY = (

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react"
 import { Card, Label, Mini, NavBtn, Pill, Stat } from "@/components/atoms"
+import Monthly, {
+  type MonthlyLabels,
+  type MonthlyMode,
+} from "@/components/charts/Monthly"
+import type {
+  MonthlyEvent,
+  MonthlyHover,
+  MonthlyYear,
+} from "@/components/charts/monthly-geometry"
 import Trend, { type TrendChartType } from "@/components/charts/Trend"
 import type { TrendYear } from "@/components/charts/trend-geometry"
 
@@ -48,6 +57,74 @@ const TREND_LABELS = {
   avgLabel: "AVG",
 }
 
+const MONTHLY_SAMPLE: MonthlyYear[] = [
+  {
+    year: 2018,
+    monthly: [
+      57_842, 64_119, 56_996, 50_874, 47_249, 45_523, 47_178, 47_044, 45_890,
+      50_140, 51_344, 53_401,
+    ],
+  },
+  {
+    year: 2019,
+    monthly: [
+      59_173, 51_607, 51_810, 49_419, 49_259, 48_268, 50_511, 47_366, 47_152,
+      52_257, 51_507, 53_676,
+    ],
+  },
+  {
+    year: 2020,
+    monthly: [
+      55_503, 50_192, 65_405, 78_625, 50_899, 47_519, 47_837, 47_995, 47_887,
+      54_403, 64_135, 65_560,
+    ],
+  },
+  {
+    year: 2021,
+    monthly: [
+      66_830, 53_690, 56_274, 56_400, 50_640, 49_054, 50_138, 49_853, 47_708,
+      50_794, 53_220, 55_625,
+    ],
+  },
+]
+
+const MONTHLY_LABELS: MonthlyLabels = {
+  months: [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ],
+  monthsLong: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+  deathsCount: "Deaths",
+}
+
+const MONTHLY_EVENTS: MonthlyEvent[] = [
+  { year: 2020, month: 2, label: "COVID-19" },
+  { year: 2020, month: 10, label: "2nd wave" },
+]
+
 const Playground = () => {
   const [locale, setLocale] = useState<"en" | "fr">("en")
   const [view, setView] = useState<"overview" | "year" | "comparison">(
@@ -55,6 +132,15 @@ const Playground = () => {
   )
   const [chartType, setChartType] = useState<TrendChartType>("area")
   const [hoveredYear, setHoveredYear] = useState<number | null>(null)
+  const [monthlyMode, setMonthlyMode] = useState<MonthlyMode>("single")
+  const [monthlySelected, setMonthlySelected] = useState<number[]>([2018, 2020])
+  const [monthlyHover, setMonthlyHover] = useState<MonthlyHover | null>(null)
+
+  const toggleSelected = (year: number) => {
+    setMonthlySelected((prev) =>
+      prev.includes(year) ? prev.filter((y) => y !== year) : [...prev, year]
+    )
+  }
 
   return (
     <main className="flex flex-col gap-12 p-12">
@@ -148,6 +234,47 @@ const Playground = () => {
             hoveredYear={hoveredYear}
             setHoveredYear={setHoveredYear}
             labels={TREND_LABELS}
+          />
+        </Card>
+      </Section>
+
+      <Section title="MonthlyChart — single / compare">
+        <div className="flex gap-2">
+          <Pill
+            active={monthlyMode === "single"}
+            onClick={() => setMonthlyMode("single")}
+          >
+            single
+          </Pill>
+          <Pill
+            active={monthlyMode === "compare"}
+            onClick={() => setMonthlyMode("compare")}
+          >
+            compare
+          </Pill>
+        </div>
+        {monthlyMode === "compare" && (
+          <div className="flex flex-wrap gap-2">
+            {MONTHLY_SAMPLE.map((y) => (
+              <Pill
+                key={y.year}
+                active={monthlySelected.includes(y.year)}
+                onClick={() => toggleSelected(y.year)}
+              >
+                {y.year}
+              </Pill>
+            ))}
+          </div>
+        )}
+        <Card className="w-full">
+          <Monthly
+            years={MONTHLY_SAMPLE}
+            mode={monthlyMode}
+            selected={monthlySelected}
+            events={MONTHLY_EVENTS}
+            hovered={monthlyHover}
+            setHovered={setMonthlyHover}
+            labels={MONTHLY_LABELS}
           />
         </Card>
       </Section>


### PR DESCRIPTION
Closes #238

## Summary

Ports `NEW_VERSION/charts-monthly.jsx` as `src/components/charts/Monthly.tsx`, an SVG-inline TS component with two modes:

- **single** — last year highlighted in `--color-accent`, previous years rendered as ghost lines (opacity 0.18), events (canicules / COVID etc.) overlaid as warn-colored annotations.
- **compare** — N selected years drawn in cycling token colors, inline legend at the top, events suppressed.

Hover is controlled (`hovered` / `setHovered`), tokens come from Graphite CSS variables (no `palette` prop, no hex), pure geometry helpers extracted into `monthly-geometry.ts` with deterministic path output. Wired into `/playground` next to TrendChart with a 2018–2021 dataset and COVID-19 / 2nd-wave events.

## Test plan

- [x] `yarn test` — 124/124 passing locally (12 geometry + 10 render added)
- [x] `yarn type-check` — green
- [x] `yarn lint` — green
- [x] `yarn build` — green
- [x] Manual smoke on `/playground`: single ghost lines + events render, compare legend + multi-series + tooltip ("APRIL 2020 / 78,625" matches dataset), console clean
- [ ] CI green on alpha

## Notes

- `area` and `bar` modes from the source file are intentionally out of scope (issue body) — same call as 3.1.
- Visual regression is sub-issue #240, not part of this PR.