### PR TITLE
feat(charts): DistributionChart SVG component (Lot 3 / 3.3)

### DIFF
--- a/__tests__/components/charts/distribution-geometry.test.ts
+++ b/__tests__/components/charts/distribution-geometry.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  DISTRIBUTION_BUCKET_COUNT,
+  DISTRIBUTION_PADDING,
+  DISTRIBUTION_RATE_DOMAIN,
+  DISTRIBUTION_RATE_TICKS,
+  DISTRIBUTION_TICK_COUNT,
+  applyGenderFilter,
+  buildDistributionGeometry,
+  computeDistributionDomainMax,
+  computeDistributionYTicks,
+  projectDistributionRateY,
+  projectDistributionValueY,
+  type DistributionYear,
+} from "@/components/charts/distribution-geometry"
+
+const mkYear = (
+  year: number,
+  bucketValue: number,
+  rate: number,
+  m = 50,
+  f = 50
+): DistributionYear => ({
+  year,
+  buckets: Array.from({ length: DISTRIBUTION_BUCKET_COUNT }, () => bucketValue),
+  rate,
+  m,
+  f,
+})
+
+const sample: DistributionYear[] = [
+  mkYear(2018, 50_000, 0.91),
+  mkYear(2019, 55_000, 0.92),
+  mkYear(2020, 60_000, 0.99),
+]
+
+describe("applyGenderFilter", () => {
+  test("returns the years unchanged when gender is 'all'", () => {
+    const out = applyGenderFilter(sample, "all")
+    expect(out).toEqual(sample)
+    expect(out).toBe(sample)
+  })
+
+  test("scales each bucket by the male ratio when gender is 'm'", () => {
+    const years: DistributionYear[] = [
+      { year: 2020, buckets: [10, 20, 30], rate: 0.95, m: 20, f: 80 },
+    ]
+    const out = applyGenderFilter(years, "m")
+    expect(out[0]!.buckets).toEqual([2, 4, 6])
+  })
+
+  test("scales each bucket by the female ratio when gender is 'f'", () => {
+    const years: DistributionYear[] = [
+      { year: 2020, buckets: [10, 20, 30], rate: 0.95, m: 20, f: 80 },
+    ]
+    const out = applyGenderFilter(years, "f")
+    expect(out[0]!.buckets).toEqual([8, 16, 24])
+  })
+
+  test("rounds scaled bucket values", () => {
+    const years: DistributionYear[] = [
+      { year: 2020, buckets: [3, 7, 11], rate: 0.95, m: 1, f: 2 },
+    ]
+    const out = applyGenderFilter(years, "m")
+    expect(out[0]!.buckets).toEqual([1, 2, 4])
+  })
+
+  test("returns the year unchanged when m+f is zero (no division by zero)", () => {
+    const years: DistributionYear[] = [
+      { year: 2020, buckets: [10, 20, 30], rate: 0.95, m: 0, f: 0 },
+    ]
+    const out = applyGenderFilter(years, "m")
+    expect(out[0]).toBe(years[0])
+  })
+
+  test("does not mutate the input array or the per-year buckets", () => {
+    const years: DistributionYear[] = [
+      { year: 2020, buckets: [10, 20, 30], rate: 0.95, m: 20, f: 80 },
+    ]
+    const copy = [...years]
+    const bucketCopy = [...years[0]!.buckets]
+    applyGenderFilter(years, "m")
+    expect(years).toEqual(copy)
+    expect(years[0]!.buckets).toEqual(bucketCopy)
+  })
+})
+
+describe("computeDistributionDomainMax", () => {
+  test("rounds the max total up to the nearest 100k", () => {
+    // Total per year = 50_000 * 10 = 500_000 ; 55_000 * 10 = 550_000 ; 60_000 * 10 = 600_000
+    expect(computeDistributionDomainMax(sample)).toBe(600_000)
+  })
+
+  test("rounds 540k up to 600k", () => {
+    const years: DistributionYear[] = [mkYear(2018, 54_000, 0.91)] // total 540_000
+    expect(computeDistributionDomainMax(years)).toBe(600_000)
+  })
+
+  test("returns a sane default for an empty dataset", () => {
+    expect(computeDistributionDomainMax([])).toBe(100_000)
+  })
+
+  test("returns the default when all totals are zero", () => {
+    const years: DistributionYear[] = [
+      { year: 2018, buckets: Array(10).fill(0), rate: 0.9, m: 50, f: 50 },
+    ]
+    expect(computeDistributionDomainMax(years)).toBe(100_000)
+  })
+
+  test("scales to 700k for a COVID-style peak", () => {
+    const years: DistributionYear[] = [mkYear(2020, 67_000, 0.99)] // total 670_000
+    expect(computeDistributionDomainMax(years)).toBe(700_000)
+  })
+})
+
+describe("computeDistributionYTicks", () => {
+  test("returns 4 evenly-spaced ticks from 0 to niceMax", () => {
+    expect(computeDistributionYTicks(600_000)).toEqual([
+      0, 200_000, 400_000, 600_000,
+    ])
+  })
+
+  test("adapts to a 700k domain", () => {
+    const ticks = computeDistributionYTicks(700_000)
+    expect(ticks).toHaveLength(DISTRIBUTION_TICK_COUNT)
+    expect(ticks[0]).toBe(0)
+    expect(ticks[3]).toBe(700_000)
+  })
+})
+
+describe("rate projection", () => {
+  test("min rate maps to the bottom of the inner box", () => {
+    const innerH = 386
+    expect(projectDistributionRateY(DISTRIBUTION_RATE_DOMAIN.min, innerH)).toBe(
+      DISTRIBUTION_PADDING.top + innerH
+    )
+  })
+
+  test("max rate maps to the top of the inner box", () => {
+    const innerH = 386
+    expect(projectDistributionRateY(DISTRIBUTION_RATE_DOMAIN.max, innerH)).toBe(
+      DISTRIBUTION_PADDING.top
+    )
+  })
+
+  test("a rate at midpoint projects halfway down the inner box", () => {
+    const innerH = 386
+    const mid =
+      (DISTRIBUTION_RATE_DOMAIN.min + DISTRIBUTION_RATE_DOMAIN.max) / 2
+    expect(projectDistributionRateY(mid, innerH)).toBeCloseTo(
+      DISTRIBUTION_PADDING.top + innerH / 2,
+      5
+    )
+  })
+
+  test("rate ticks are 0.85, 0.90, 0.95, 1.00", () => {
+    expect([...DISTRIBUTION_RATE_TICKS]).toEqual([0.85, 0.9, 0.95, 1.0])
+  })
+})
+
+describe("value projection", () => {
+  test("zero maps to the bottom of the inner box", () => {
+    const innerH = 386
+    expect(projectDistributionValueY(0, 600_000, innerH)).toBe(
+      DISTRIBUTION_PADDING.top + innerH
+    )
+  })
+
+  test("niceMax maps to the top of the inner box", () => {
+    const innerH = 386
+    expect(projectDistributionValueY(600_000, 600_000, innerH)).toBe(
+      DISTRIBUTION_PADDING.top
+    )
+  })
+})
+
+describe("buildDistributionGeometry", () => {
+  test("inner box reflects width/height minus padding", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect(g.innerW).toBe(
+      900 - DISTRIBUTION_PADDING.left - DISTRIBUTION_PADDING.right
+    )
+    expect(g.innerH).toBe(
+      460 - DISTRIBUTION_PADDING.top - DISTRIBUTION_PADDING.bottom
+    )
+  })
+
+  test("clamps innerW to the minimum on tiny containers", () => {
+    const g = buildDistributionGeometry(sample, 50, 460)
+    expect(g.innerW).toBe(100)
+  })
+
+  test("xs and centers have one entry per year, evenly spaced", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect(g.xs).toHaveLength(3)
+    expect(g.centers).toHaveLength(3)
+    const groupW = g.innerW / 3
+    expect(g.groupW).toBeCloseTo(groupW, 5)
+    // First slot starts at padL + (groupW - barW) / 2
+    const expectedFirstLeft = DISTRIBUTION_PADDING.left + (groupW - g.barW) / 2
+    expect(g.xs[0]).toBeCloseTo(expectedFirstLeft, 5)
+    // Center of first slot is at padL + groupW / 2
+    expect(g.centers[0]).toBeCloseTo(DISTRIBUTION_PADDING.left + groupW / 2, 5)
+    // Slots are spaced by groupW
+    expect(g.centers[1]! - g.centers[0]!).toBeCloseTo(groupW, 5)
+  })
+
+  test("barW is 72% of the slot width", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    const groupW = g.innerW / 3
+    expect(g.barW).toBeCloseTo(groupW * 0.72, 5)
+  })
+
+  test("series has one entry per year with 10 stacked bars", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect(g.series.map((s) => s.year)).toEqual([2018, 2019, 2020])
+    for (const s of g.series) {
+      expect(s.bars).toHaveLength(DISTRIBUTION_BUCKET_COUNT)
+    }
+  })
+
+  test("stacked bars are contiguous: each bar's bottom matches the previous bar's top", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    const bars = g.series[0]!.bars
+    for (let i = 1; i < bars.length; i++) {
+      expect(bars[i]!.yBot).toBeCloseTo(bars[i - 1]!.yTop, 5)
+    }
+  })
+
+  test("total per series equals the sum of its buckets", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect(g.series[0]!.total).toBe(50_000 * 10)
+    expect(g.series[2]!.total).toBe(60_000 * 10)
+  })
+
+  test("rateY uses the [0.80, 1.05] domain over innerH", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    // 2018 rate=0.91 → (0.91 - 0.80) / 0.25 = 0.44
+    // y = padT + innerH * (1 - 0.44) = 24 + 386 * 0.56 = 240.16
+    expect(g.series[0]!.rateY).toBeCloseTo(240.16, 1)
+  })
+
+  test("ratePath starts with M then L commands at series centers", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect(g.ratePath.startsWith("M ")).toBe(true)
+    expect(g.ratePath.split(" L ").length).toBe(g.series.length)
+  })
+
+  test("returns finite, non-empty geometry on an empty dataset", () => {
+    const g = buildDistributionGeometry([], 900, 460)
+    expect(g.series).toEqual([])
+    expect(g.xs).toEqual([])
+    expect(g.centers).toEqual([])
+    expect(g.barW).toBe(0)
+    expect(g.niceMax).toBe(100_000)
+    expect(g.ratePath).toBe("")
+  })
+
+  test("yTicksLeft span [0, niceMax] in 4 evenly-spaced steps", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect(g.yTicksLeft).toEqual([0, 200_000, 400_000, 600_000])
+  })
+
+  test("yTicksRight reflect the fixed rate domain", () => {
+    const g = buildDistributionGeometry(sample, 900, 460)
+    expect([...g.yTicksRight]).toEqual([0.85, 0.9, 0.95, 1.0])
+  })
+})

--- a/__tests__/components/charts/distribution.test.tsx
+++ b/__tests__/components/charts/distribution.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, test, vi } from "vitest"
+
+import Distribution, {
+  type DistributionLabels,
+} from "@/components/charts/Distribution"
+import type { DistributionYear } from "@/components/charts/distribution-geometry"
+
+const AGE_BUCKETS = [
+  "0-9",
+  "10-19",
+  "20-29",
+  "30-39",
+  "40-49",
+  "50-59",
+  "60-69",
+  "70-79",
+  "80-89",
+  "90+",
+]
+
+const labels: DistributionLabels = {
+  deathsCount: "Deaths",
+  mortalityRate: "Mortality rate",
+  ageBuckets: AGE_BUCKETS,
+}
+
+const mkYear = (
+  year: number,
+  rate: number,
+  m = 50,
+  f = 50
+): DistributionYear => ({
+  year,
+  buckets: [
+    1_000, 2_000, 3_000, 5_000, 10_000, 30_000, 60_000, 90_000, 60_000, 20_000,
+  ],
+  rate,
+  m,
+  f,
+})
+
+const sample: DistributionYear[] = [
+  mkYear(2018, 0.91),
+  mkYear(2019, 0.92),
+  mkYear(2020, 0.99),
+]
+
+const baseProps = {
+  years: sample,
+  gender: "all" as const,
+  hovered: null,
+  setHovered: () => {},
+  labels,
+}
+
+describe("Distribution", () => {
+  test("renders an svg with one stacked-bar group per year", () => {
+    const { container } = render(<Distribution {...baseProps} />)
+    const svg = container.querySelector("svg")
+    expect(svg).not.toBeNull()
+    const groups = container.querySelectorAll("g[data-year]")
+    expect(groups.length).toBe(sample.length)
+  })
+
+  test("renders 10 stacked rects per year (the 10 age buckets)", () => {
+    const { container } = render(<Distribution {...baseProps} />)
+    for (const y of sample.map((s) => s.year)) {
+      const group = container.querySelector(`g[data-year="${y}"]`)
+      expect(group).not.toBeNull()
+      // bucket rects are the colored ones (not the transparent hit zone)
+      const bucketRects = group!.querySelectorAll(
+        'rect[fill]:not([fill="transparent"])'
+      )
+      expect(bucketRects.length).toBe(10)
+    }
+  })
+
+  test("renders the mortality rate overlay path", () => {
+    const { container } = render(<Distribution {...baseProps} />)
+    const ratePath = container.querySelector(
+      'path[stroke="var(--color-danger)"]'
+    )
+    expect(ratePath).not.toBeNull()
+    expect(ratePath!.getAttribute("d")).toMatch(/^M /)
+  })
+
+  test("renders the year tick labels on the x-axis", () => {
+    render(<Distribution {...baseProps} />)
+    expect(screen.getByText("2018")).toBeInTheDocument()
+    expect(screen.getByText("2020")).toBeInTheDocument()
+  })
+
+  test("renders the legend with all 10 age bucket labels", () => {
+    render(<Distribution {...baseProps} />)
+    for (const label of AGE_BUCKETS) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  test("renders the axis labels (deaths + mortality rate)", () => {
+    render(<Distribution {...baseProps} />)
+    expect(screen.getByText("Deaths")).toBeInTheDocument()
+    expect(screen.getByText("Mortality rate")).toBeInTheDocument()
+  })
+
+  test("dims other years' bars when one year is hovered (controlled)", () => {
+    const { container } = render(<Distribution {...baseProps} hovered={2019} />)
+    const group2018 = container.querySelector('g[data-year="2018"]')
+    const group2019 = container.querySelector('g[data-year="2019"]')
+    expect(group2018).not.toBeNull()
+    const dimmed2018 = group2018!.querySelectorAll('rect[opacity="0.4"]')
+    expect(dimmed2018.length).toBe(10)
+    // The hovered year stays at full opacity
+    const dimmed2019 = group2019!.querySelectorAll('rect[opacity="0.4"]')
+    expect(dimmed2019.length).toBe(0)
+  })
+
+  test("forces the rate label visible for the hovered year", () => {
+    // 2019 is at index 1, which is normally hidden (every 2 years).
+    const { rerender } = render(<Distribution {...baseProps} />)
+    expect(screen.queryByText("0.92%")).toBeNull()
+    rerender(<Distribution {...baseProps} hovered={2019} />)
+    expect(screen.getByText("0.92%")).toBeInTheDocument()
+  })
+
+  test("calls setHovered when entering and leaving a year's hit zone", () => {
+    const setHovered = vi.fn()
+    const { container } = render(
+      <Distribution {...baseProps} setHovered={setHovered} />
+    )
+    const group2020 = container.querySelector('g[data-year="2020"]')
+    expect(group2020).not.toBeNull()
+    fireEvent.mouseEnter(group2020!)
+    expect(setHovered).toHaveBeenCalledWith(2020)
+    fireEvent.mouseLeave(group2020!)
+    expect(setHovered).toHaveBeenLastCalledWith(null)
+  })
+
+  test("rescales the bars when the gender filter changes", () => {
+    // Buckets sum to 200_000 → niceMax = 200_000. With gender='m' the ratio is
+    // 0.8, so each bucket scales to 80% of its raw value but the total stays
+    // below 200_000 (160_000) → niceMax remains 200_000. That makes the
+    // rendered bar heights directly proportional to the gender ratio.
+    const yearsAsymmetric: DistributionYear[] = [
+      {
+        year: 2020,
+        buckets: [
+          1_000, 2_000, 3_000, 5_000, 9_000, 20_000, 50_000, 70_000, 30_000,
+          10_000,
+        ],
+        rate: 0.99,
+        m: 80,
+        f: 20,
+      },
+    ]
+    const totalBucketHeight = (root: ParentNode): number => {
+      const rects = root.querySelectorAll(
+        'rect[fill]:not([fill="transparent"])'
+      )
+      let sum = 0
+      rects.forEach((r) => {
+        sum += parseFloat(r.getAttribute("height") || "0")
+      })
+      return sum
+    }
+    const { container, rerender } = render(
+      <Distribution {...baseProps} years={yearsAsymmetric} gender="all" />
+    )
+    const heightAll = totalBucketHeight(container)
+    rerender(<Distribution {...baseProps} years={yearsAsymmetric} gender="m" />)
+    const heightM = totalBucketHeight(container)
+    expect(heightM / heightAll).toBeCloseTo(0.8, 1)
+  })
+})

--- a/__tests__/utils/distribution.test.tsx
+++ b/__tests__/utils/distribution.test.tsx
@@ -3,7 +3,7 @@ import {
   getLineLabelDisplay,
   getBarLabelDisplay,
   getFormattedLineLabel,
-} from "../../src/components/charts/Distribution"
+} from "../../src/components/charts/DistributionLegacy"
 
 describe("Test getBarLabelDisplay()", () => {
   const data = [

--- a/src/components/charts/Distribution.tsx
+++ b/src/components/charts/Distribution.tsx
@@ -1,207 +1,324 @@
-import type { ChartDataset, ChartOptions } from "chart.js"
-import type { Context } from "chartjs-plugin-datalabels"
+import { useEffect, useRef, useState } from "react"
 
-import { useIntl } from "react-intl"
-import { Bar } from "react-chartjs-2"
-
-import ChartDataLabels from "chartjs-plugin-datalabels"
-import AnnotationPlugin from "chartjs-plugin-annotation"
 import {
-  Title,
-  BarElement,
-  LineElement,
-  LinearScale,
-  PointElement,
-  CategoryScale,
-  Chart as ChartJS,
-} from "chart.js"
+  DISTRIBUTION_BUCKET_COUNT,
+  DISTRIBUTION_PADDING,
+  applyGenderFilter,
+  buildDistributionGeometry,
+  projectDistributionRateY,
+  projectDistributionValueY,
+  type DistributionGender,
+  type DistributionYear,
+} from "./distribution-geometry"
 
-import useMortality from "@/services/mortality"
-import useTheme from "@/services/use-charts-theme"
-import useRawMortality from "@/services/raw-mortality"
-
-ChartJS.register(
-  Title,
-  BarElement,
-  LineElement,
-  LinearScale,
-  PointElement,
-  CategoryScale,
-  ChartDataLabels,
-  AnnotationPlugin
-)
-
-export const getBarLabelDisplay = ({
-  chart,
-  active,
-  dataIndex,
-  dataset: { data },
-}: Context) => {
-  const { scales } = chart as ChartJS
-  const scale = scales["y"]
-  const { max } = scale
-  const value = ((data || [])[dataIndex] || 0) as number
-
-  return active ? true : value > max * 0.05 ? "auto" : false
+export type DistributionLabels = {
+  deathsCount: string
+  mortalityRate: string
+  ageBuckets: string[]
 }
 
-export const getFormattedLineLabel = (value: number) => `${value.toFixed(2)}%`
+export type DistributionProps = {
+  years: DistributionYear[]
+  gender: DistributionGender
+  hovered: number | null
+  setHovered: (year: number | null) => void
+  labels: DistributionLabels
+  height?: number
+  formatCompact?: (n: number) => string
+}
 
-export const getLineLabelDisplay = ({ active }: Context) =>
-  active ? true : "auto"
+const BUCKET_OPACITY_PERCENT = [
+  null,
+  6,
+  12,
+  19,
+  27,
+  35,
+  46,
+  58,
+  75,
+  100,
+] as const
 
-const Distribution = () => {
-  useRawMortality()
-  const theme = useTheme()
-  const [mortality] = useMortality()
-  const { formatMessage: fm, formatNumber: fn } = useIntl()
-  const { labels, data, ratio, ageGroups } = mortality as Mortality
+const VERTICAL_X_LABEL_THRESHOLD = 18
+const X_LABEL_OFFSET = 20
+const RATE_LABEL_OFFSET = 8
+const RATE_LABEL_EVERY = 2
+const VALUE_LABEL_MIN_RATIO = 0.05
+const VALUE_LABEL_MIN_BAR_WIDTH = 18
 
-  const tr = (str: string) => fm({ id: str })
+const defaultFormatCompact = (n: number): string =>
+  new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n)
 
-  const getAgeGroup = (datasetIndex: number) => {
-    const ageGroup = ageGroups[datasetIndex - 1]
+const fillForBucket = (i: number): string => {
+  const pct = BUCKET_OPACITY_PERCENT[i]
+  if (pct == null) return "var(--color-grid)"
+  return `color-mix(in srgb, var(--color-accent) ${pct}%, transparent)`
+}
 
-    return `${ageGroup}${
-      datasetIndex > 10
-        ? "+"
-        : ` ${tr("to")} ${ageGroup + 9} ${tr("years old")}`
-    }`
-  }
+const Distribution = ({
+  years,
+  gender,
+  hovered,
+  setHovered,
+  labels,
+  height = 460,
+  formatCompact = defaultFormatCompact,
+}: DistributionProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(900)
 
-  const getLongFormat = (
-    dataIndex: number,
-    datasetIndex: number,
-    value: number
-  ) => {
-    return `${dataIndex + 2000}
-${tr("Deaths count")}: ${fn(value)}
-${tr("Age group")}: ${getAgeGroup(datasetIndex)}`
-  }
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) return
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry) setWidth(entry.contentRect.width)
+    })
+    ro.observe(node)
+    return () => ro.disconnect()
+  }, [])
 
-  const getShortFormat = (datasetIndex: number, value: number) => {
-    const ageGroup = ageGroups[datasetIndex - 1]
-    return `${(value / 1000).toFixed()}K\n${ageGroup}-${ageGroup + 10}`
-  }
+  const filtered = applyGenderFilter(years, gender)
+  const {
+    innerW,
+    innerH,
+    barW,
+    xs,
+    yTicksLeft,
+    yTicksRight,
+    series,
+    ratePath,
+    niceMax,
+  } = buildDistributionGeometry(filtered, width, height)
+  const { left: padL, top: padT } = DISTRIBUTION_PADDING
 
-  const getFormattedBarLabel = (
-    value: number,
-    { active, dataIndex, datasetIndex }: Context
-  ) => {
-    if (active) {
-      return getLongFormat(dataIndex, datasetIndex, value)
-    } else if (value > 1000) {
-      return getShortFormat(datasetIndex, value)
-    }
-    return fn(Math.round(value))
-  }
+  const useVerticalXLabels = series.length > VERTICAL_X_LABEL_THRESHOLD
 
-  const bars = data.map((ageGroup, i) => ({
-    yAxisID: "y",
-    data: ageGroup,
-    label: `bar-${i}`,
-    backgroundColor: theme.primary.background,
-    hoverBackgroundColor: theme.primary.hover?.background,
-    borderWidth: { top: 1, right: 0, bottom: 0, left: 0 },
-    datalabels: {
-      borderRadius: 4,
-      display: getBarLabelDisplay,
-      textAlign: "center" as const,
-      formatter: getFormattedBarLabel,
-      borderColor: theme.primary.label?.hover?.border,
-      font: { size: 10, weight: "bold" as const },
-      borderWidth: ({ active }: Context) => (active ? 2 : 0),
-      backgroundColor: ({ active }: Context) =>
-        active
-          ? theme.primary.label?.hover?.background
-          : theme.primary.label?.background,
-      color: ({ active }: Context) =>
-        active ? theme.primary.label?.hover?.text : theme.primary.label?.text,
-    },
-  }))
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <svg
+        width={width}
+        height={height}
+        style={{ display: "block", overflow: "visible" }}
+      >
+        {yTicksLeft.map((v) => {
+          const y = projectDistributionValueY(v, niceMax, innerH)
+          return (
+            <g key={`ytl-${v}`}>
+              <line
+                x1={padL}
+                y1={y}
+                x2={padL + innerW}
+                y2={y}
+                stroke="var(--color-grid)"
+                strokeWidth="1"
+              />
+              <text
+                x={padL - 10}
+                y={y + 3}
+                textAnchor="end"
+                fontSize="10"
+                className="font-mono"
+                fill="var(--color-text-faint)"
+                letterSpacing="0.04em"
+              >
+                {formatCompact(v)}
+              </text>
+            </g>
+          )
+        })}
 
-  const datasets = [
-    {
-      data: ratio,
-      tension: 0.4,
-      yAxisID: "y2",
-      label: "Ratio",
-      borderWidth: 3,
-      pointRadius: 5,
-      type: "line" as const,
-      borderColor: theme.secondary.border,
-      pointBackgroundColor: theme.secondary.border,
-      datalabels: {
-        offset: 3,
-        clamp: true,
-        borderRadius: 4,
-        align: "end" as const,
-        anchor: "end" as const,
-        color: theme.secondary.label?.text,
-        display: getLineLabelDisplay,
-        textAlign: "center" as const,
-        formatter: getFormattedLineLabel,
-        font: { weight: "bold" as const },
-        backgroundColor: theme.secondary.label?.background,
-        padding: { top: 4, right: 5, bottom: 4, left: 5 },
-      },
-    },
-    ...bars,
-  ] as ChartDataset<"bar">[]
+        {yTicksRight.map((v) => (
+          <text
+            key={`ytr-${v}`}
+            x={padL + innerW + 10}
+            y={projectDistributionRateY(v, innerH) + 3}
+            fontSize="10"
+            className="font-mono"
+            fill="var(--color-text-faint)"
+            letterSpacing="0.04em"
+          >
+            {v.toFixed(2)}%
+          </text>
+        ))}
 
-  const options = {
-    maintainAspectRatio: false,
-    animation: { duration: 0 },
-    interaction: { mode: "nearest" as const },
-    plugins: {
-      legend: { display: false },
-      tooltip: { enabled: false },
-    },
-    scales: {
-      x: {
-        type: "category" as const,
-        stacked: true,
-        grid: {
-          display: false,
-          drawBorder: false,
-        },
-        ticks: {
-          color: theme.scale.text,
-        },
-      },
-      y: {
-        stacked: true,
-        type: "linear" as const,
-        ticks: {
-          padding: 10,
-          color: theme.scale.text,
-        },
-        grid: {
-          lineWidth: 1,
-          drawTicks: false,
-          drawBorder: false,
-          borderDash: [3, 3],
-          color: theme.scale.border,
-        },
-      },
-      y2: {
-        type: "linear" as const,
-        position: "right" as const,
-        ticks: {
-          padding: 10,
-          stepSize: 0.1,
-          color: theme.scale.text,
-          callback: getFormattedLineLabel,
-        },
-        grid: {
-          display: false,
-          drawBorder: false,
-        },
-      },
-    },
-  } as ChartOptions<"bar">
+        {series.map((s, i) => {
+          const dimmed = hovered != null && hovered !== s.year
+          return (
+            <g
+              key={`g-${s.year}`}
+              data-year={s.year}
+              onMouseEnter={() => setHovered(s.year)}
+              onMouseLeave={() => setHovered(null)}
+              style={{ cursor: "pointer" }}
+            >
+              <rect
+                x={xs[i]}
+                y={padT}
+                width={barW}
+                height={innerH}
+                fill="transparent"
+                pointerEvents="all"
+              />
+              {s.bars.map((b) => {
+                const bh = Math.max(0, b.yBot - b.yTop)
+                const isLarge = b.value > niceMax * VALUE_LABEL_MIN_RATIO
+                const showLabel =
+                  isLarge && barW > VALUE_LABEL_MIN_BAR_WIDTH && bh > 10
+                return (
+                  <g key={`b-${s.year}-${b.bucketIndex}`}>
+                    <rect
+                      x={xs[i]}
+                      y={b.yTop}
+                      width={barW}
+                      height={bh}
+                      fill={fillForBucket(b.bucketIndex)}
+                      stroke="var(--color-surface)"
+                      strokeWidth="0.5"
+                      opacity={dimmed ? 0.4 : 1}
+                    />
+                    {showLabel && (
+                      <text
+                        x={xs[i]! + barW / 2}
+                        y={(b.yTop + b.yBot) / 2 + 3}
+                        textAnchor="middle"
+                        fontSize="8.5"
+                        className="font-mono"
+                        fill={
+                          b.bucketIndex >= 7
+                            ? "var(--color-surface)"
+                            : "var(--color-text-dim)"
+                        }
+                        style={{ pointerEvents: "none" }}
+                      >
+                        {formatCompact(b.value)}
+                      </text>
+                    )}
+                  </g>
+                )
+              })}
+            </g>
+          )
+        })}
 
-  return <Bar data={{ labels, datasets }} options={options} />
+        {series.length > 1 && (
+          <path
+            d={ratePath}
+            fill="none"
+            stroke="var(--color-danger)"
+            strokeWidth="2"
+            strokeLinejoin="round"
+          />
+        )}
+
+        {series.map((s, i) => {
+          const showLabel = i % RATE_LABEL_EVERY === 0 || hovered === s.year
+          return (
+            <g key={`r-${s.year}`} style={{ pointerEvents: "none" }}>
+              <circle
+                cx={s.centerX}
+                cy={s.rateY}
+                r="3"
+                fill="var(--color-surface)"
+                stroke="var(--color-danger)"
+                strokeWidth="1.5"
+              />
+              {showLabel && (
+                <text
+                  x={s.centerX}
+                  y={s.rateY - RATE_LABEL_OFFSET}
+                  textAnchor="middle"
+                  fontSize="9"
+                  className="font-mono"
+                  fill="var(--color-danger)"
+                  fontWeight="600"
+                >
+                  {s.rate.toFixed(2)}%
+                </text>
+              )}
+            </g>
+          )
+        })}
+
+        {series.map((s) => (
+          <text
+            key={`x-${s.year}`}
+            x={s.centerX}
+            y={padT + innerH + X_LABEL_OFFSET}
+            textAnchor="middle"
+            fontSize="10"
+            className="font-mono"
+            fill="var(--color-text-dim)"
+            letterSpacing="0.04em"
+            style={
+              useVerticalXLabels
+                ? { writingMode: "vertical-rl", textOrientation: "mixed" }
+                : undefined
+            }
+          >
+            {s.year}
+          </text>
+        ))}
+
+        <text
+          x={padL - 44}
+          y={padT - 6}
+          fontSize="9.5"
+          className="font-mono uppercase"
+          fill="var(--color-text-faint)"
+          letterSpacing="0.08em"
+        >
+          {labels.deathsCount}
+        </text>
+        <text
+          x={padL + innerW + 34}
+          y={padT - 6}
+          fontSize="9.5"
+          className="font-mono uppercase"
+          fill="var(--color-danger)"
+          letterSpacing="0.08em"
+        >
+          {labels.mortalityRate}
+        </text>
+      </svg>
+
+      <div
+        className="font-mono text-text-dim flex flex-wrap"
+        style={{
+          gap: 14,
+          marginTop: 8,
+          paddingLeft: padL,
+          fontSize: 10,
+          letterSpacing: "0.04em",
+        }}
+      >
+        {Array.from({ length: DISTRIBUTION_BUCKET_COUNT }, (_, i) => (
+          <div
+            key={`legend-${i}`}
+            style={{ display: "flex", alignItems: "center", gap: 5 }}
+          >
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                background: fillForBucket(i),
+                border: "1px solid var(--color-border)",
+              }}
+            />
+            <span>{labels.ageBuckets[i] ?? ""}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export default Distribution
+
+export type {
+  DistributionGender,
+  DistributionYear,
+} from "./distribution-geometry"

--- a/src/components/charts/Distribution.tsx
+++ b/src/components/charts/Distribution.tsx
@@ -27,18 +27,7 @@ export type DistributionProps = {
   formatCompact?: (n: number) => string
 }
 
-const BUCKET_OPACITY_PERCENT = [
-  null,
-  6,
-  12,
-  19,
-  27,
-  35,
-  46,
-  58,
-  75,
-  100,
-] as const
+const BUCKET_OPACITY_PERCENT = [3, 6, 12, 19, 27, 35, 46, 58, 75, 100] as const
 
 const VERTICAL_X_LABEL_THRESHOLD = 18
 const X_LABEL_OFFSET = 20
@@ -48,16 +37,13 @@ const VALUE_LABEL_MIN_RATIO = 0.05
 const VALUE_LABEL_MIN_BAR_WIDTH = 18
 
 const defaultFormatCompact = (n: number): string =>
-  new Intl.NumberFormat("en-US", {
+  new Intl.NumberFormat(undefined, {
     notation: "compact",
     maximumFractionDigits: 1,
   }).format(n)
 
-const fillForBucket = (i: number): string => {
-  const pct = BUCKET_OPACITY_PERCENT[i]
-  if (pct == null) return "var(--color-grid)"
-  return `color-mix(in srgb, var(--color-accent) ${pct}%, transparent)`
-}
+const fillForBucket = (i: number): string =>
+  `color-mix(in srgb, var(--color-accent) ${BUCKET_OPACITY_PERCENT[i] ?? 0}%, transparent)`
 
 const Distribution = ({
   years,

--- a/src/components/charts/DistributionLegacy.tsx
+++ b/src/components/charts/DistributionLegacy.tsx
@@ -1,0 +1,207 @@
+import type { ChartDataset, ChartOptions } from "chart.js"
+import type { Context } from "chartjs-plugin-datalabels"
+
+import { useIntl } from "react-intl"
+import { Bar } from "react-chartjs-2"
+
+import ChartDataLabels from "chartjs-plugin-datalabels"
+import AnnotationPlugin from "chartjs-plugin-annotation"
+import {
+  Title,
+  BarElement,
+  LineElement,
+  LinearScale,
+  PointElement,
+  CategoryScale,
+  Chart as ChartJS,
+} from "chart.js"
+
+import useMortality from "@/services/mortality"
+import useTheme from "@/services/use-charts-theme"
+import useRawMortality from "@/services/raw-mortality"
+
+ChartJS.register(
+  Title,
+  BarElement,
+  LineElement,
+  LinearScale,
+  PointElement,
+  CategoryScale,
+  ChartDataLabels,
+  AnnotationPlugin
+)
+
+export const getBarLabelDisplay = ({
+  chart,
+  active,
+  dataIndex,
+  dataset: { data },
+}: Context) => {
+  const { scales } = chart as ChartJS
+  const scale = scales["y"]
+  const { max } = scale
+  const value = ((data || [])[dataIndex] || 0) as number
+
+  return active ? true : value > max * 0.05 ? "auto" : false
+}
+
+export const getFormattedLineLabel = (value: number) => `${value.toFixed(2)}%`
+
+export const getLineLabelDisplay = ({ active }: Context) =>
+  active ? true : "auto"
+
+const Distribution = () => {
+  useRawMortality()
+  const theme = useTheme()
+  const [mortality] = useMortality()
+  const { formatMessage: fm, formatNumber: fn } = useIntl()
+  const { labels, data, ratio, ageGroups } = mortality as Mortality
+
+  const tr = (str: string) => fm({ id: str })
+
+  const getAgeGroup = (datasetIndex: number) => {
+    const ageGroup = ageGroups[datasetIndex - 1]
+
+    return `${ageGroup}${
+      datasetIndex > 10
+        ? "+"
+        : ` ${tr("to")} ${ageGroup + 9} ${tr("years old")}`
+    }`
+  }
+
+  const getLongFormat = (
+    dataIndex: number,
+    datasetIndex: number,
+    value: number
+  ) => {
+    return `${dataIndex + 2000}
+${tr("Deaths count")}: ${fn(value)}
+${tr("Age group")}: ${getAgeGroup(datasetIndex)}`
+  }
+
+  const getShortFormat = (datasetIndex: number, value: number) => {
+    const ageGroup = ageGroups[datasetIndex - 1]
+    return `${(value / 1000).toFixed()}K\n${ageGroup}-${ageGroup + 10}`
+  }
+
+  const getFormattedBarLabel = (
+    value: number,
+    { active, dataIndex, datasetIndex }: Context
+  ) => {
+    if (active) {
+      return getLongFormat(dataIndex, datasetIndex, value)
+    } else if (value > 1000) {
+      return getShortFormat(datasetIndex, value)
+    }
+    return fn(Math.round(value))
+  }
+
+  const bars = data.map((ageGroup, i) => ({
+    yAxisID: "y",
+    data: ageGroup,
+    label: `bar-${i}`,
+    backgroundColor: theme.primary.background,
+    hoverBackgroundColor: theme.primary.hover?.background,
+    borderWidth: { top: 1, right: 0, bottom: 0, left: 0 },
+    datalabels: {
+      borderRadius: 4,
+      display: getBarLabelDisplay,
+      textAlign: "center" as const,
+      formatter: getFormattedBarLabel,
+      borderColor: theme.primary.label?.hover?.border,
+      font: { size: 10, weight: "bold" as const },
+      borderWidth: ({ active }: Context) => (active ? 2 : 0),
+      backgroundColor: ({ active }: Context) =>
+        active
+          ? theme.primary.label?.hover?.background
+          : theme.primary.label?.background,
+      color: ({ active }: Context) =>
+        active ? theme.primary.label?.hover?.text : theme.primary.label?.text,
+    },
+  }))
+
+  const datasets = [
+    {
+      data: ratio,
+      tension: 0.4,
+      yAxisID: "y2",
+      label: "Ratio",
+      borderWidth: 3,
+      pointRadius: 5,
+      type: "line" as const,
+      borderColor: theme.secondary.border,
+      pointBackgroundColor: theme.secondary.border,
+      datalabels: {
+        offset: 3,
+        clamp: true,
+        borderRadius: 4,
+        align: "end" as const,
+        anchor: "end" as const,
+        color: theme.secondary.label?.text,
+        display: getLineLabelDisplay,
+        textAlign: "center" as const,
+        formatter: getFormattedLineLabel,
+        font: { weight: "bold" as const },
+        backgroundColor: theme.secondary.label?.background,
+        padding: { top: 4, right: 5, bottom: 4, left: 5 },
+      },
+    },
+    ...bars,
+  ] as ChartDataset<"bar">[]
+
+  const options = {
+    maintainAspectRatio: false,
+    animation: { duration: 0 },
+    interaction: { mode: "nearest" as const },
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: false },
+    },
+    scales: {
+      x: {
+        type: "category" as const,
+        stacked: true,
+        grid: {
+          display: false,
+          drawBorder: false,
+        },
+        ticks: {
+          color: theme.scale.text,
+        },
+      },
+      y: {
+        stacked: true,
+        type: "linear" as const,
+        ticks: {
+          padding: 10,
+          color: theme.scale.text,
+        },
+        grid: {
+          lineWidth: 1,
+          drawTicks: false,
+          drawBorder: false,
+          borderDash: [3, 3],
+          color: theme.scale.border,
+        },
+      },
+      y2: {
+        type: "linear" as const,
+        position: "right" as const,
+        ticks: {
+          padding: 10,
+          stepSize: 0.1,
+          color: theme.scale.text,
+          callback: getFormattedLineLabel,
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
+        },
+      },
+    },
+  } as ChartOptions<"bar">
+
+  return <Bar data={{ labels, datasets }} options={options} />
+}
+
+export default Distribution

--- a/src/components/charts/distribution-geometry.ts
+++ b/src/components/charts/distribution-geometry.ts
@@ -1,0 +1,174 @@
+export type DistributionGender = "all" | "m" | "f"
+
+export type DistributionYear = {
+  year: number
+  buckets: number[]
+  rate: number
+  m: number
+  f: number
+}
+
+export const DISTRIBUTION_PADDING = {
+  left: 64,
+  right: 64,
+  top: 24,
+  bottom: 50,
+} as const
+
+export const DISTRIBUTION_RATE_DOMAIN = { min: 0.8, max: 1.05 } as const
+export const DISTRIBUTION_RATE_TICKS = [0.85, 0.9, 0.95, 1.0] as const
+export const DISTRIBUTION_TICK_COUNT = 4
+export const DISTRIBUTION_BUCKET_COUNT = 10
+
+const BAR_WIDTH_RATIO = 0.72
+const NICE_MAX_STEP = 100_000
+const DEFAULT_NICE_MAX = NICE_MAX_STEP
+const MIN_INNER_WIDTH = 100
+
+export const applyGenderFilter = (
+  years: DistributionYear[],
+  gender: DistributionGender
+): DistributionYear[] => {
+  if (gender === "all") return years
+  return years.map((y) => {
+    const total = y.m + y.f
+    if (total === 0) return y
+    const ratio = (gender === "m" ? y.m : y.f) / total
+    return {
+      ...y,
+      buckets: y.buckets.map((b) => Math.round(b * ratio)),
+    }
+  })
+}
+
+export const computeDistributionDomainMax = (
+  years: DistributionYear[]
+): number => {
+  if (years.length === 0) return DEFAULT_NICE_MAX
+  const maxTotal = Math.max(
+    ...years.map((y) => y.buckets.reduce((s, b) => s + b, 0))
+  )
+  if (maxTotal <= 0) return DEFAULT_NICE_MAX
+  return Math.ceil(maxTotal / NICE_MAX_STEP) * NICE_MAX_STEP
+}
+
+export const computeDistributionYTicks = (niceMax: number): number[] => {
+  const intervals = DISTRIBUTION_TICK_COUNT - 1
+  return Array.from(
+    { length: DISTRIBUTION_TICK_COUNT },
+    (_, i) => (niceMax * i) / intervals
+  )
+}
+
+export const projectDistributionValueY = (
+  value: number,
+  niceMax: number,
+  innerH: number
+): number => DISTRIBUTION_PADDING.top + innerH * (1 - value / niceMax)
+
+export const projectDistributionRateY = (
+  rate: number,
+  innerH: number
+): number => {
+  const { min, max } = DISTRIBUTION_RATE_DOMAIN
+  return DISTRIBUTION_PADDING.top + innerH * (1 - (rate - min) / (max - min))
+}
+
+export type DistributionBar = {
+  bucketIndex: number
+  value: number
+  yTop: number
+  yBot: number
+}
+
+export type DistributionSeries = {
+  year: number
+  total: number
+  bars: DistributionBar[]
+  rate: number
+  rateY: number
+  centerX: number
+}
+
+export type DistributionGeometry = {
+  innerW: number
+  innerH: number
+  niceMax: number
+  barW: number
+  groupW: number
+  xs: number[]
+  centers: number[]
+  yTicksLeft: number[]
+  yTicksRight: readonly number[]
+  series: DistributionSeries[]
+  ratePath: string
+}
+
+export const buildDistributionGeometry = (
+  years: DistributionYear[],
+  width: number,
+  height: number
+): DistributionGeometry => {
+  const {
+    left: padL,
+    right: padR,
+    top: padT,
+    bottom: padB,
+  } = DISTRIBUTION_PADDING
+  const innerW = Math.max(MIN_INNER_WIDTH, width - padL - padR)
+  const innerH = height - padT - padB
+
+  const niceMax = computeDistributionDomainMax(years)
+  const yTicksLeft = computeDistributionYTicks(niceMax)
+
+  const groupCount = years.length
+  const groupW = groupCount > 0 ? innerW / groupCount : innerW
+  const barW = groupCount > 0 ? groupW * BAR_WIDTH_RATIO : 0
+
+  const xs: number[] = []
+  const centers: number[] = []
+  for (let i = 0; i < groupCount; i++) {
+    const left = padL + groupW * i + (groupW - barW) / 2
+    xs.push(left)
+    centers.push(left + barW / 2)
+  }
+
+  const series: DistributionSeries[] = years.map((y, i) => {
+    let cum = 0
+    const bars: DistributionBar[] = y.buckets.map((value, bucketIndex) => {
+      const yTop = projectDistributionValueY(cum + value, niceMax, innerH)
+      const yBot = projectDistributionValueY(cum, niceMax, innerH)
+      cum += value
+      return { bucketIndex, value, yTop, yBot }
+    })
+    return {
+      year: y.year,
+      total: cum,
+      bars,
+      rate: y.rate,
+      rateY: projectDistributionRateY(y.rate, innerH),
+      centerX: centers[i] ?? padL,
+    }
+  })
+
+  const ratePath = series
+    .map(
+      (s, i) =>
+        `${i === 0 ? "M" : "L"} ${s.centerX.toFixed(2)} ${s.rateY.toFixed(2)}`
+    )
+    .join(" ")
+
+  return {
+    innerW,
+    innerH,
+    niceMax,
+    barW,
+    groupW,
+    xs,
+    centers,
+    yTicksLeft,
+    yTicksRight: DISTRIBUTION_RATE_TICKS,
+    series,
+    ratePath,
+  }
+}

--- a/src/pages/distribution.tsx
+++ b/src/pages/distribution.tsx
@@ -1,4 +1,4 @@
-import DistributionChart from "@/components/charts/Distribution"
+import DistributionChart from "@/components/charts/DistributionLegacy"
 
 const Distribution = () => {
   return (

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react"
 import { Card, Label, Mini, NavBtn, Pill, Stat } from "@/components/atoms"
+import Distribution, {
+  type DistributionLabels,
+} from "@/components/charts/Distribution"
+import type {
+  DistributionGender,
+  DistributionYear,
+} from "@/components/charts/distribution-geometry"
 import Monthly, {
   type MonthlyLabels,
   type MonthlyMode,
@@ -125,6 +132,76 @@ const MONTHLY_EVENTS: MonthlyEvent[] = [
   { year: 2020, month: 10, label: "2nd wave" },
 ]
 
+const DISTRIBUTION_SAMPLE: DistributionYear[] = [
+  {
+    year: 2017,
+    buckets: [
+      1_990, 1_240, 2_810, 5_090, 11_830, 31_230, 70_220, 156_340, 218_650,
+      106_874,
+    ],
+    rate: 0.91,
+    m: 290_840,
+    f: 315_434,
+  },
+  {
+    year: 2018,
+    buckets: [
+      1_950, 1_220, 2_780, 5_010, 11_690, 30_910, 69_540, 154_830, 217_220,
+      114_498,
+    ],
+    rate: 0.91,
+    m: 292_410,
+    f: 317_238,
+  },
+  {
+    year: 2019,
+    buckets: [
+      1_900, 1_180, 2_700, 4_870, 11_350, 30_010, 67_410, 150_300, 215_430,
+      128_093,
+    ],
+    rate: 0.91,
+    m: 294_010,
+    f: 319_233,
+  },
+  {
+    year: 2020,
+    buckets: [
+      2_010, 1_310, 2_960, 5_310, 12_360, 32_650, 73_130, 162_990, 232_870,
+      143_332,
+    ],
+    rate: 0.99,
+    m: 322_510,
+    f: 346_412,
+  },
+  {
+    year: 2021,
+    buckets: [
+      1_980, 1_290, 2_910, 5_220, 12_140, 32_080, 71_890, 160_220, 229_530,
+      142_908,
+    ],
+    rate: 0.97,
+    m: 318_420,
+    f: 341_748,
+  },
+]
+
+const DISTRIBUTION_LABELS: DistributionLabels = {
+  deathsCount: "Deaths",
+  mortalityRate: "Mortality rate",
+  ageBuckets: [
+    "0-9",
+    "10-19",
+    "20-29",
+    "30-39",
+    "40-49",
+    "50-59",
+    "60-69",
+    "70-79",
+    "80-89",
+    "90+",
+  ],
+}
+
 const Playground = () => {
   const [locale, setLocale] = useState<"en" | "fr">("en")
   const [view, setView] = useState<"overview" | "year" | "comparison">(
@@ -135,6 +212,11 @@ const Playground = () => {
   const [monthlyMode, setMonthlyMode] = useState<MonthlyMode>("single")
   const [monthlySelected, setMonthlySelected] = useState<number[]>([2018, 2020])
   const [monthlyHover, setMonthlyHover] = useState<MonthlyHover | null>(null)
+  const [distributionGender, setDistributionGender] =
+    useState<DistributionGender>("all")
+  const [distributionHover, setDistributionHover] = useState<number | null>(
+    null
+  )
 
   const toggleSelected = (year: number) => {
     setMonthlySelected((prev) =>
@@ -275,6 +357,38 @@ const Playground = () => {
             hovered={monthlyHover}
             setHovered={setMonthlyHover}
             labels={MONTHLY_LABELS}
+          />
+        </Card>
+      </Section>
+
+      <Section title="DistributionChart — gender filter + hover">
+        <div className="flex gap-2">
+          <Pill
+            active={distributionGender === "all"}
+            onClick={() => setDistributionGender("all")}
+          >
+            all
+          </Pill>
+          <Pill
+            active={distributionGender === "m"}
+            onClick={() => setDistributionGender("m")}
+          >
+            male
+          </Pill>
+          <Pill
+            active={distributionGender === "f"}
+            onClick={() => setDistributionGender("f")}
+          >
+            female
+          </Pill>
+        </div>
+        <Card className="w-full">
+          <Distribution
+            years={DISTRIBUTION_SAMPLE}
+            gender={distributionGender}
+            hovered={distributionHover}
+            setHovered={setDistributionHover}
+            labels={DISTRIBUTION_LABELS}
           />
         </Card>
       </Section>


### PR DESCRIPTION
Closes #239

## Summary

Pure SVG inline component porting `NEW_VERSION/charts-distribution.jsx` as `src/components/charts/Distribution.tsx`, with controlled hover, gender filter (`all` / `m` / `f`), 100k-rounded adaptive deaths axis, and a fixed `[0.80, 1.05]` mortality-rate axis. Geometry helpers extracted to `distribution-geometry.ts`; tokens via CSS variables, bucket shades via `color-mix(--color-accent, …)`.

The pre-existing chart.js `Distribution.tsx` is renamed to `DistributionLegacy.tsx` so the `/distribution` route keeps rendering until Lot 5 rewires it; the new SVG component is wired into `/playground` next to TrendChart and MonthlyChart.

## Test plan

- [x] `yarn test` — 166 passed (31 new geometry tests + 10 new component tests)
- [x] `yarn type-check` — clean
- [x] `yarn lint` — clean
- [x] `yarn build` — clean
- [x] Manual `/playground` — chart renders, gender toggle rescales bars, hover dims other years and forces the rate label visible
- [x] Manual `/distribution` — legacy chart still resolves
- [ ] CI green on `alpha`

## Notes

- Visual regression snapshot is out of scope here — that's #240 (Lot 3.4).
- Wiring the new component into the real `/distribution` view is Lot 5.
- Removing `chart.js` / `react-chartjs-2` from `package.json` is Lot 6 (cleanup).