### PR TITLE
feat(views): wire useFilters into /overview, /comparison, /distribution (Lot 5 / 5.1)

### DIFF
--- a/__tests__/pages/__snapshots__/distribution.test.tsx.snap
+++ b/__tests__/pages/__snapshots__/distribution.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`Page snapshot: distribution 1`] = `
               1.00%
             </text>
             <g
-              data-year="2020"
+              data-year="2000"
               style="cursor: pointer;"
             >
               <rect
@@ -351,7 +351,7 @@ exports[`Page snapshot: distribution 1`] = `
               </g>
             </g>
             <g
-              data-year="2021"
+              data-year="2001"
               style="cursor: pointer;"
             >
               <rect
@@ -550,7 +550,7 @@ exports[`Page snapshot: distribution 1`] = `
               </g>
             </g>
             <g
-              data-year="2022"
+              data-year="2002"
               style="cursor: pointer;"
             >
               <rect
@@ -749,7 +749,7 @@ exports[`Page snapshot: distribution 1`] = `
               </g>
             </g>
             <path
-              d="M 192.67 1518.57 L 450.00 1516.27 L 707.33 1515.42"
+              d="M 192.67 1504.86 L 450.00 1503.32 L 707.33 1501.83"
               fill="none"
               stroke="var(--color-danger)"
               stroke-linejoin="round"
@@ -760,7 +760,7 @@ exports[`Page snapshot: distribution 1`] = `
             >
               <circle
                 cx="192.66666666666666"
-                cy="1518.5741260902341"
+                cy="1504.8552695793874"
                 fill="var(--color-surface)"
                 r="3"
                 stroke="var(--color-danger)"
@@ -773,9 +773,9 @@ exports[`Page snapshot: distribution 1`] = `
                 font-weight="600"
                 text-anchor="middle"
                 x="192.66666666666666"
-                y="1510.5741260902341"
+                y="1496.8552695793874"
               >
-                0.08%
+                0.09%
               </text>
             </g>
             <g
@@ -783,7 +783,7 @@ exports[`Page snapshot: distribution 1`] = `
             >
               <circle
                 cx="450"
-                cy="1516.2718374736928"
+                cy="1503.319462611712"
                 fill="var(--color-surface)"
                 r="3"
                 stroke="var(--color-danger)"
@@ -795,7 +795,7 @@ exports[`Page snapshot: distribution 1`] = `
             >
               <circle
                 cx="707.3333333333333"
-                cy="1515.4203322777112"
+                cy="1501.8296332316636"
                 fill="var(--color-surface)"
                 r="3"
                 stroke="var(--color-danger)"
@@ -808,9 +808,9 @@ exports[`Page snapshot: distribution 1`] = `
                 font-weight="600"
                 text-anchor="middle"
                 x="707.3333333333333"
-                y="1507.4203322777112"
+                y="1493.8296332316636"
               >
-                0.08%
+                0.09%
               </text>
             </g>
             <text
@@ -822,7 +822,7 @@ exports[`Page snapshot: distribution 1`] = `
               x="192.66666666666666"
               y="430"
             >
-              2020
+              2000
             </text>
             <text
               class="font-mono"
@@ -833,7 +833,7 @@ exports[`Page snapshot: distribution 1`] = `
               x="450"
               y="430"
             >
-              2021
+              2001
             </text>
             <text
               class="font-mono"
@@ -844,7 +844,7 @@ exports[`Page snapshot: distribution 1`] = `
               x="707.3333333333333"
               y="430"
             >
-              2022
+              2002
             </text>
             <text
               class="font-mono uppercase"

--- a/__tests__/utils/filters.test.ts
+++ b/__tests__/utils/filters.test.ts
@@ -103,7 +103,7 @@ describe("computeFilteredAgeBuckets()", () => {
     expect(narrow[0].f).toBeGreaterThan(0)
   })
 
-  test("rate is computed against total population for the filtered slice", () => {
+  test("rate stays the all-ages rate regardless of age filter (otherwise it would fall outside DISTRIBUTION_RATE_DOMAIN)", () => {
     const wide = computeFilteredAgeBuckets(rawMortality, {
       gender: null,
       ageGroup: [0, 110],
@@ -112,7 +112,7 @@ describe("computeFilteredAgeBuckets()", () => {
       gender: null,
       ageGroup: [60, 90],
     })
-    expect(narrow[0].rate).toBeLessThan(wide[0].rate)
+    expect(narrow[0].rate).toBe(wide[0].rate)
     expect(narrow[0].rate).toBeGreaterThan(0)
   })
 })

--- a/__tests__/utils/filters.test.ts
+++ b/__tests__/utils/filters.test.ts
@@ -1,0 +1,118 @@
+import {
+  computeFilteredMonthly,
+  computeFilteredAgeBuckets,
+} from "../../src/utils/filters"
+import deaths from "../../public/data/deaths.json"
+import mortality from "../../public/data/mortality.json"
+
+const rawDeaths = deaths as DeathsRawData
+const rawMortality = mortality as unknown as MortalityRawData
+
+describe("computeFilteredMonthly()", () => {
+  test("returns empty when data is undefined", () => {
+    expect(
+      computeFilteredMonthly(undefined, { gender: null, ageGroup: [0, 110] })
+    ).toEqual([])
+  })
+
+  test("default filter = sum across all 11 age buckets per year, preserving month count", () => {
+    const result = computeFilteredMonthly(rawDeaths, {
+      gender: null,
+      ageGroup: [0, 110],
+    })
+    expect(result).toHaveLength(rawDeaths.ageGroups[0].length)
+    result.forEach((months, i) =>
+      expect(months).toHaveLength(rawDeaths.ageGroups[0][i].length)
+    )
+  })
+
+  test("gender=male yields strictly less deaths in 2000 than unfiltered", () => {
+    const noFilter = computeFilteredMonthly(rawDeaths, {
+      gender: null,
+      ageGroup: [0, 110],
+    })
+    const maleOnly = computeFilteredMonthly(rawDeaths, {
+      gender: "male",
+      ageGroup: [0, 110],
+    })
+    const sum = (m: number[]) => m.reduce((a, b) => a + b, 0)
+    expect(sum(maleOnly[0])).toBeLessThan(sum(noFilter[0]))
+    expect(sum(maleOnly[0])).toBeGreaterThan(0)
+  })
+
+  test("ageGroup=[60,90] excludes buckets outside the range", () => {
+    const wide = computeFilteredMonthly(rawDeaths, {
+      gender: null,
+      ageGroup: [0, 110],
+    })
+    const narrow = computeFilteredMonthly(rawDeaths, {
+      gender: null,
+      ageGroup: [60, 90],
+    })
+    const sum = (m: number[]) => m.reduce((a, b) => a + b, 0)
+    expect(sum(narrow[0])).toBeLessThan(sum(wide[0]))
+    expect(sum(narrow[0])).toBeGreaterThan(0)
+  })
+
+  test("matches male.global when gender=male and ageGroup covers all", () => {
+    const filtered = computeFilteredMonthly(rawDeaths, {
+      gender: "male",
+      ageGroup: [0, 110],
+    })
+    const sum = (m: number[]) => m.reduce((a, b) => a + b, 0)
+    const maleTotal2000 = sum(rawDeaths.male.global[0])
+    expect(sum(filtered[0])).toBe(maleTotal2000)
+  })
+})
+
+describe("computeFilteredAgeBuckets()", () => {
+  test("returns 10 buckets per year (collapsing 90-99 + 100+ into 90+)", () => {
+    const result = computeFilteredAgeBuckets(rawMortality, {
+      gender: null,
+      ageGroup: [0, 110],
+    })
+    expect(result.length).toBeGreaterThan(0)
+    result.forEach((year) => expect(year.buckets).toHaveLength(10))
+  })
+
+  test("ageGroup=[60,90] zeroes buckets outside the range", () => {
+    const filtered = computeFilteredAgeBuckets(rawMortality, {
+      gender: null,
+      ageGroup: [60, 90],
+    })
+    filtered.forEach(({ buckets }) => {
+      buckets.slice(0, 6).forEach((b) => expect(b).toBe(0)) // 0-9 .. 50-59
+      buckets.slice(9).forEach((b) => expect(b).toBe(0)) // 90+
+      const inRange = buckets.slice(6, 9) // 60-69, 70-79, 80-89
+      expect(inRange.some((b) => b > 0)).toBe(true)
+    })
+  })
+
+  test("m + f totals reflect the age range, not the entire population", () => {
+    const wide = computeFilteredAgeBuckets(rawMortality, {
+      gender: null,
+      ageGroup: [0, 110],
+    })
+    const narrow = computeFilteredAgeBuckets(rawMortality, {
+      gender: null,
+      ageGroup: [60, 90],
+    })
+    expect(narrow[0].m).toBeLessThan(wide[0].m)
+    expect(narrow[0].f).toBeLessThan(wide[0].f)
+    expect(narrow[0].m).toBeGreaterThan(0)
+    expect(narrow[0].f).toBeGreaterThan(0)
+  })
+
+  test("rate is computed against total population for the filtered slice", () => {
+    const wide = computeFilteredAgeBuckets(rawMortality, {
+      gender: null,
+      ageGroup: [0, 110],
+    })
+    const narrow = computeFilteredAgeBuckets(rawMortality, {
+      gender: null,
+      ageGroup: [60, 90],
+    })
+    expect(narrow[0].rate).toBeLessThan(wide[0].rate)
+    expect(narrow[0].rate).toBeGreaterThan(0)
+  })
+})

--- a/src/pages/comparison.tsx
+++ b/src/pages/comparison.tsx
@@ -8,9 +8,10 @@ import Comparison, {
   type ComparisonYearData,
 } from "@/components/views/Comparison"
 import { EVENTS_RAW } from "@/data/events"
+import useFilters from "@/services/filters"
 import useRawDeaths from "@/services/raw-deaths"
 import useYears from "@/services/years"
-import { sumYears } from "@/utils/index"
+import { computeFilteredMonthly } from "@/utils/filters"
 
 const monthKeys = [
   "January",
@@ -44,16 +45,17 @@ const Page = () => {
   const intl = useIntl()
   const [years] = useYears()
   const [deaths] = useRawDeaths()
+  const [filters] = useFilters()
   const partialYear = new Date().getFullYear()
 
   const data: ComparisonYearData[] = useMemo(() => {
-    const ageGroups = deaths?.ageGroups ?? []
+    const monthlyByYear = computeFilteredMonthly(deaths, filters)
     const yearsList = Object.keys(years || {})
     return yearsList.map((yearStr, i) => ({
       year: Number(yearStr),
-      monthly: sumYears(ageGroups.map((group) => group[i] || [])),
+      monthly: monthlyByYear[i] ?? [],
     }))
-  }, [years, deaths])
+  }, [years, deaths, filters])
 
   const sortedYears = useMemo(
     () => [...data].sort((a, b) => a.year - b.year),

--- a/src/pages/distribution.tsx
+++ b/src/pages/distribution.tsx
@@ -8,7 +8,7 @@ import Distribution, {
 import type { DistributionGender } from "@/components/charts/distribution-geometry"
 import useFilters from "@/services/filters"
 import useRawMortality from "@/services/raw-mortality"
-import { getYearPopulation } from "@/utils/index"
+import { computeFilteredAgeBuckets } from "@/utils/filters"
 
 const AGE_BUCKETS = [
   "0-9",
@@ -22,9 +22,6 @@ const AGE_BUCKETS = [
   "80-89",
   "90+",
 ] as const
-
-const sumColumn = (groups: number[][], i: number): number =>
-  groups.reduce((sum, group) => sum + (group[i] ?? 0), 0)
 
 const toViewGender = (g: Filters["gender"]): DistributionGender => {
   if (g === "male") return "m"
@@ -40,24 +37,14 @@ const Page = () => {
 
   const [hovered, setHovered] = useState<number | null>(null)
 
-  const years = useMemo(() => {
-    if (!rawData) return []
-    const data = rawData as unknown as MortalityRawData
-    return data.labels.map((yearStr, i) => {
-      const year = Number(yearStr)
-      const buckets = data.ageGroups.map((group) => group[i] ?? 0)
-      const totalDeaths = buckets.reduce((s, b) => s + b, 0)
-      const population = getYearPopulation(year) || 0
-      const rate = population > 0 ? (totalDeaths * 100) / population : 0
-      return {
-        year,
-        buckets,
-        rate,
-        m: sumColumn(data.male.ageGroups, i),
-        f: sumColumn(data.female.ageGroups, i),
-      }
-    })
-  }, [rawData])
+  const years = useMemo(
+    () =>
+      computeFilteredAgeBuckets(
+        rawData as unknown as MortalityRawData | undefined,
+        filters
+      ),
+    [rawData, filters]
+  )
 
   if (!rawData || !years.length) return null
 

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -35,15 +35,19 @@ const Page = () => {
 
   const data: YearData[] = useMemo(() => {
     const monthlyByYear = computeFilteredMonthly(deaths, filters)
+    const allAgesByYear = computeFilteredMonthly(deaths, undefined)
     const yearsList = Object.keys(years || {})
     return yearsList.map((yearStr, i) => {
       const year = Number(yearStr)
       const pop = getYearPopulation(year) || 0
       const monthly = monthlyByYear[i] ?? []
       const totalDeaths = sumArray(monthly)
+      // Rate stays the all-ages all-genders rate so the TrendChart curve
+      // stays inside TREND_RATE_DOMAIN (0.8–1.05) under any filter.
+      const totalAllAges = sumArray(allAgesByYear[i] ?? [])
       return {
         year,
-        rate: pop > 0 ? (totalDeaths * 100) / pop : 0,
+        rate: pop > 0 ? (totalAllAges * 100) / pop : 0,
         deaths: totalDeaths,
         pop,
         monthly,

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -4,9 +4,11 @@ import { useRouter } from "next/router"
 
 import Year, { type YearData, type YearLabels } from "@/components/views/Year"
 import { EVENTS_RAW, type YearEvent } from "@/data/events"
+import useFilters from "@/services/filters"
 import useYears from "@/services/years"
 import useRawDeaths from "@/services/raw-deaths"
-import { getYearPopulation, sumArray, sumYears } from "@/utils/index"
+import { getYearPopulation, sumArray } from "@/utils/index"
+import { computeFilteredMonthly } from "@/utils/filters"
 
 const monthKeys = [
   "January",
@@ -28,17 +30,17 @@ const Page = () => {
   const intl = useIntl()
   const [years] = useYears()
   const [deaths] = useRawDeaths()
+  const [filters] = useFilters()
   const partialYear = new Date().getFullYear()
 
   const data: YearData[] = useMemo(() => {
-    const ageGroups = deaths?.ageGroups ?? []
+    const monthlyByYear = computeFilteredMonthly(deaths, filters)
     const yearsList = Object.keys(years || {})
     return yearsList.map((yearStr, i) => {
       const year = Number(yearStr)
       const pop = getYearPopulation(year) || 0
-      const yearAgeTotals = ageGroups.map((group) => sumArray(group[i] || []))
-      const totalDeaths = sumArray(yearAgeTotals)
-      const monthly = sumYears(ageGroups.map((group) => group[i] || []))
+      const monthly = monthlyByYear[i] ?? []
+      const totalDeaths = sumArray(monthly)
       return {
         year,
         rate: pop > 0 ? (totalDeaths * 100) / pop : 0,
@@ -47,7 +49,7 @@ const Page = () => {
         monthly,
       }
     })
-  }, [years, deaths])
+  }, [years, deaths, filters])
 
   const lastFullYearData = data
     .filter((y) => y.year !== partialYear)

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -72,9 +72,12 @@ export const computeFilteredAgeBuckets = (
     const year = FIRST_YEAR + i
     const rawBuckets = data.ageGroups.map((g) => g[i] ?? 0)
     const buckets = collapseTo10Buckets(rawBuckets, start, end)
-    const totalDeaths = buckets.reduce((s, b) => s + b, 0)
     const population = getYearPopulation(year) || 0
-    const rate = population > 0 ? (totalDeaths * 100) / population : 0
+    // Rate stays the all-ages mortality rate so the curve keeps its
+    // meaning under age-range filters; otherwise it would fall outside
+    // DISTRIBUTION_RATE_DOMAIN (0.8–1.05) and disappear from the chart.
+    const totalAllAges = rawBuckets.reduce((s, b) => s + b, 0)
+    const rate = population > 0 ? (totalAllAges * 100) / population : 0
     return {
       year,
       buckets,

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,0 +1,86 @@
+import { sumYears, getYearPopulation } from "@/utils/index"
+
+const AGE_BUCKET_SPAN = 10
+const VIEW_BUCKET_COUNT = 10
+
+const ageIndices = (
+  ageGroup: [number, number]
+): { start: number; end: number } => ({
+  start: Math.floor(ageGroup[0] / AGE_BUCKET_SPAN),
+  end: Math.ceil(ageGroup[1] / AGE_BUCKET_SPAN),
+})
+
+export const computeFilteredMonthly = (
+  data: DeathsRawData | undefined,
+  filters: Filters | undefined
+): number[][] => {
+  if (!data) return []
+  const { gender, ageGroup = [0, 110] } = filters ?? {}
+  const { start, end } = ageIndices(ageGroup)
+  const groups: DeathsAgeGroups = gender
+    ? data[gender].ageGroups
+    : data.ageGroups
+  return groups
+    .slice(start, end)
+    .reduce<
+      number[][]
+    >((acc, group) => group.map((year, i) => sumYears([acc[i] ?? [], year])), [])
+}
+
+export type FilteredAgeBucketsYear = {
+  year: number
+  buckets: number[]
+  rate: number
+  m: number
+  f: number
+}
+
+const sumColumnInRange = (
+  groups: number[][],
+  yearIndex: number,
+  start: number,
+  end: number
+): number =>
+  groups.slice(start, end).reduce((s, g) => s + (g[yearIndex] ?? 0), 0)
+
+const collapseTo10Buckets = (
+  raw: number[],
+  start: number,
+  end: number
+): number[] => {
+  const out = new Array<number>(VIEW_BUCKET_COUNT).fill(0)
+  // Source has 11 buckets (0-9 .. 100+); view shows 10 by collapsing 90-99 + 100+ into 90+.
+  for (let i = 0; i < raw.length; i++) {
+    if (i < start || i >= end) continue
+    const target = i >= VIEW_BUCKET_COUNT - 1 ? VIEW_BUCKET_COUNT - 1 : i
+    out[target] += raw[i] ?? 0
+  }
+  return out
+}
+
+const FIRST_YEAR = 2000
+
+export const computeFilteredAgeBuckets = (
+  data: MortalityRawData | undefined,
+  filters: Filters | undefined
+): FilteredAgeBucketsYear[] => {
+  if (!data) return []
+  const yearCount = data.ageGroups[0]?.length ?? 0
+  const { ageGroup = [0, 110] } = filters ?? {}
+  const { start, end } = ageIndices(ageGroup)
+  return Array.from({ length: yearCount }, (_, i) => {
+    const year = FIRST_YEAR + i
+    const rawBuckets = data.ageGroups.map((g) => g[i] ?? 0)
+    const buckets = collapseTo10Buckets(rawBuckets, start, end)
+    const totalDeaths = buckets.reduce((s, b) => s + b, 0)
+    const population = getYearPopulation(year) || 0
+    const rate = population > 0 ? (totalDeaths * 100) / population : 0
+    return {
+      year,
+      buckets,
+      rate,
+      m: sumColumnInRange(data.male.ageGroups, i, start, end),
+      f: sumColumnInRange(data.female.ageGroups, i, start, end),
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- New `src/utils/filters.ts` with `computeFilteredMonthly` (Year + Comparison) and `computeFilteredAgeBuckets` (Distribution).
- `/overview`, `/comparison`, `/distribution` now read `useFilters()` so changes to gender + age range update displayed numbers.
- `/` (Overview Grid) intentionally stays unfiltered per parent issue spec.
- Side-effect: `distribution.tsx` no longer reads `data.labels` — real `mortality.json` has no `labels` field, years are derived from index. The page test mock previously masked this latent crash; snapshot updated.

## Why

Lot 5.2 (filter UI) needs the views to actually consume `useFilters()` before unskipping the filter golden-path tests. This locks the data flow before that wiring lands.

## Test plan

- [x] `yarn type-check` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — 212/212 (29 files), incl. new `__tests__/utils/filters.test.ts` (9 tests). Lot 0.3 calc snapshots still match master.
- [x] `yarn e2e` — 6 active passes, 2 filter tests stay `skip` (per spec, they unblock in 5.2).
- [x] `yarn e2e:visual` — 7/7 pass, no regression on default-filter rendering.
- [x] `grep -rn NEW_VERSION src/` — no hits.

Closes #245