### PR TITLE
ci(release): authenticate checkout with PAT for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Refs #253 (Lot 7 / 7.1 — required to unblock the v2.0.0 release).

## Problem

The Release workflow has been failing on every push to `alpha` and `master` since the repo transfer (2026-04-28+):

```
[semantic-release] › ✘  EGITNOPERMISSION Cannot push to the Git repository.
remote: Permission to chewam/mortality.git denied to github-actions[bot].
```

Re-setting `secrets.PAT` did not fix it. Root cause: `actions/checkout@v3` runs without an explicit `token:`, so it persists the default `GITHUB_TOKEN` as a git credential helper. When semantic-release later runs `git push`, the credential helper wins over the env-var `GITHUB_TOKEN` set on the Release step → push goes as `github-actions[bot]` (forbidden), not as the PAT owner.

## Fix

Pass `secrets.PAT` to `actions/checkout` so the persisted git credential is the PAT itself, matching the token semantic-release uses for API calls.

## Verification

Once merged into `alpha`, the next push triggers semantic-release. Expected outcome:

- `Release` workflow goes green for the first time since the transfer.
- A `v2.0.0-alpha.1` prerelease is published (the cumulative refactor commits include `refactor!:` → major bump).
- This unblocks the eventual `alpha` → `master` merge that ships `v2.0.0` stable (PR #260 / closes #253).