### PR TITLE
fix: Monthly chart single-mode now highlights the selected year

### DIFF
--- a/src/components/charts/Monthly.tsx
+++ b/src/components/charts/Monthly.tsx
@@ -81,13 +81,22 @@ const Monthly = ({
 
   const isSingle = mode === "single"
 
-  const highlighted = isSingle
-    ? series.slice(-1)
-    : (selected
-        .map((yr) => series.find((s) => s.year === yr))
-        .filter(Boolean) as typeof series)
+  const fromSelected = selected
+    .map((yr) => series.find((s) => s.year === yr))
+    .filter(Boolean) as typeof series
 
-  const ghosts = isSingle ? series.slice(0, -1) : []
+  // Single mode pinpoints one series; fall back to the most recent year
+  // when nothing is selected so the chart never renders empty.
+  const highlighted = isSingle
+    ? fromSelected.length > 0
+      ? fromSelected.slice(0, 1)
+      : series.slice(-1)
+    : fromSelected
+
+  const highlightedYears = new Set(highlighted.map((s) => s.year))
+  const ghosts = isSingle
+    ? series.filter((s) => !highlightedYears.has(s.year))
+    : []
 
   const visibleEvents = isSingle
     ? events.filter((ev) => series.some((s) => s.year === ev.year))
@@ -110,7 +119,7 @@ const Monthly = ({
       ? null
       : (hoveredSeries.values[hovered.month] ?? null)
 
-  const labelYears = isSingle ? series.slice(-1).map((s) => s.year) : selected
+  const labelYears = highlighted.map((s) => s.year)
   const ariaLabel =
     labelYears.length > 0
       ? `${labels.deathsCount} · ${labelYears.join(", ")}`


### PR DESCRIPTION
## Summary

On `/overview`, picking any full year (e.g. 2025) showed the right headline KPIs but the monthly chart drew the **2026 partial-year line** (Jan–Mar only, 3 points) — independent of which year was active. The "Peak" mini-stat was correct (computed from `active.monthly`) but the curve next to it was for a different year. Hard to spot at first glance, easy to mis-read.

## Cause

[`Monthly.tsx:84`](src/components/charts/Monthly.tsx#L84) hard-coded `highlighted = series.slice(-1)` in single mode. That only picked the active year when "active" happened to be the last entry of the series — true for v1 because data ended at the most recent full year, but false now that the dataset ships a partial 2026.

## Fix

Drive `highlighted` from the `selected` prop in single mode too:
- `selected[0]` when provided (the page already passes `selected={[active.year]}`),
- `series.slice(-1)` as a fallback so the existing Monthly unit tests (which call single mode with `selected={[]}`) keep their previous default.

`ghosts` and `labelYears` (aria-label) read from the same source so what the chart draws and what the screen reader announces always match.

## Verified

| Route | Before | After |
| --- | --- | --- |
| `/overview?year=2025` | path = 3 points (drawn from 2026), aria=`… · 2026` | path = 12 points, aria=`… · 2025` |
| `/overview?year=2024` | path = 3 points | path = 12 points, aria=`… · 2024` |
| `/overview?year=2026` (partial) | 3 points | 3 points, aria=`… · 2026` |

- [x] `yarn test` — 204 passed (Monthly unit tests cover both `selected=[]` fallback and explicit selection)
- [x] `yarn type-check`
- [x] `yarn lint`
- [x] Local prod build (`yarn build && yarn start`) — manual screenshot diff
- [ ] CI: e2e behavior + e2e visual