### PR TITLE
ci(claude-review): target master, not the retired alpha branch

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,7 +3,7 @@ name: Claude Review
 on:
   pull_request:
     types: [opened, synchronize]
-    branches: [alpha]
+    branches: [master]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
## Why

The Claude Review workflow was wired to fire only on PRs targeting `alpha`, where the v2 refactor was developed:

```yaml
on:
  pull_request:
    types: [opened, synchronize]
    branches: [alpha]
```

Since v2.0.0 shipped and master is back to being the active branch, no automatic review runs on master PRs — #307 missed the workflow entirely.

## What

Switch the `branches:` filter to `master`. The `@claude` mention trigger (via `issue_comment`) is unchanged, so manual reviews still work everywhere.