### PR TITLE
fix(comparison): include partial current year in the picker

### DIFF
--- a/src/pages/comparison.tsx
+++ b/src/pages/comparison.tsx
@@ -46,7 +46,6 @@ const Page = () => {
   const [years] = useYears()
   const [deaths] = useRawDeaths()
   const [filters] = useFilters()
-  const partialYear = new Date().getFullYear()
 
   const data: ComparisonYearData[] = useMemo(() => {
     const monthlyByYear = computeFilteredMonthly(deaths, filters)
@@ -62,25 +61,20 @@ const Page = () => {
     [data]
   )
 
-  const fullYears = useMemo(
-    () => sortedYears.filter((y) => y.year !== partialYear),
-    [sortedYears, partialYear]
-  )
-
   // Curated default selection — years that surface notable events in the
   // chart (heatwave 2003, COVID 2020, summer 2022, recent baseline).
   // Mirrors NEW_VERSION/app.jsx initial compareYears.
   const defaultSelectedKey = useMemo(() => {
     const preferred = [2003, 2020, 2022, 2024, 2025]
-    const available = new Set(fullYears.map((y) => y.year))
+    const available = new Set(sortedYears.map((y) => y.year))
     const present = preferred.filter((y) => available.has(y))
     return present.length > 0
       ? present.join(",")
-      : fullYears
+      : sortedYears
           .slice(-3)
           .map((y) => y.year)
           .join(",")
-  }, [fullYears])
+  }, [sortedYears])
 
   // null = not yet initialized from URL/defaults (initial render before
   // router.isReady). Empty array = user-emptied selection, still rendered.
@@ -141,7 +135,7 @@ const Page = () => {
   return (
     <div className="container mx-auto px-6">
       <Comparison
-        years={fullYears}
+        years={sortedYears}
         selected={selected}
         onSelectedChange={handleSelectedChange}
         events={events}


### PR DESCRIPTION
## Summary

The Comparison view filtered out the current calendar year as a "partial year" guard. With monthly curves, the partial year just stops at the last month that has data — it doesn't plunge to zero — so excluding it altogether overcorrects. Drops the `fullYears` filter; the default selection still targets full years (2003, 2020, 2022, 2024, 2025) so the partial year is opt-in via the picker.

Distribution already includes the partial year as a (smaller) bar; this aligns Comparison with the same behaviour.

## Test plan

- [x] `yarn test` (comparison page test passes — fixture data doesn't reach the current year, so the snapshot is unaffected)
- [ ] Manual: pick 2026 in the picker, confirm the line shows JAN–MAR (current data) without dropping to zero